### PR TITLE
Enable manager View-as on proposals page

### DIFF
--- a/js/proposals.js
+++ b/js/proposals.js
@@ -9,6 +9,7 @@ import {
     setupModalListeners,
     getState,
     initializeAppState,
+    setupUserMenuAndAuth,
     SUPABASE_URL,
     SUPABASE_ANON_KEY
 } from './shared_constants.js';
@@ -19,6 +20,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     // Expose modal and Supabase for enterprise-proposals-embed.js (save to account)
     const supabase = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
     await initializeAppState(supabase);
+    await setupUserMenuAndAuth(supabase, getState());
     window.showModal = showModal;
     window.hideModal = hideModal;
     window.getState = getState;

--- a/sql/rls_managers_manage_team_crm.sql
+++ b/sql/rls_managers_manage_team_crm.sql
@@ -59,5 +59,14 @@ CREATE POLICY "Managers/Admins can manage all sequences"
   USING ((is_manager() = true) OR (is_admin() = true))
   WITH CHECK ((is_manager() = true) OR (is_admin() = true));
 
+-- ----- proposal_specs (managers save proposals to rep accounts when viewing as) -----
+DROP POLICY IF EXISTS "proposal_specs_manager_all" ON public.proposal_specs;
+CREATE POLICY "proposal_specs_manager_all"
+  ON public.proposal_specs
+  FOR ALL
+  TO public
+  USING (is_manager() = true)
+  WITH CHECK (is_manager() = true);
+
 -- Optional cleanup after the app uses client-side reassignment everywhere:
 -- DROP FUNCTION IF EXISTS public.reassign_account_to_user(bigint, uuid, boolean, boolean, boolean);

--- a/supabase/proposal_specs.sql
+++ b/supabase/proposal_specs.sql
@@ -69,6 +69,14 @@ USING (
     )
 );
 
+-- Managers: read/write any proposal_specs (requires public.is_manager() from sql/manager_helpers.sql)
+DROP POLICY IF EXISTS "proposal_specs_manager_all" ON public.proposal_specs;
+CREATE POLICY "proposal_specs_manager_all"
+ON public.proposal_specs FOR ALL
+TO authenticated
+USING (public.is_manager() = true)
+WITH CHECK (public.is_manager() = true);
+
 -- Optional: trigger to keep updated_at in sync
 CREATE OR REPLACE FUNCTION public.set_proposal_specs_updated_at()
 RETURNS TRIGGER


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The proposals page never called `setupUserMenuAndAuth`, so managers did not get the **View as** control even though `enterprise-proposals-embed.js` already loads the save-to-account picker using `getState().effectiveUserId`.

## Changes

- **`js/proposals.js`**: Import and await `setupUserMenuAndAuth(supabase, getState())` immediately after `initializeAppState`, matching other CRM pages (without `skipImpersonation`).
- **`supabase/proposal_specs.sql`** and **`sql/rls_managers_manage_team_crm.sql`**: Add an RLS policy so users for whom `is_manager()` is true can perform all operations on `proposal_specs`. Without this, inserts still fail under RLS when the account row belongs to a rep (`accounts.user_id` ≠ manager’s `auth.uid()`).

## Deploy note

If `proposal_specs` already exists in Supabase, run the new `DROP POLICY` / `CREATE POLICY` block from `sql/rls_managers_manage_team_crm.sql` (or the equivalent in `supabase/proposal_specs.sql`) in the SQL editor so manager saves succeed. This assumes `public.is_manager()` is already defined (see `sql/manager_helpers.sql`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-68fe7ec9-dee3-4526-b735-feea3896ee5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-68fe7ec9-dee3-4526-b735-feea3896ee5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

