### PR TITLE
Prune Strategic Account OS schema: Target Profile + Pursuit Thesis consolidation, Blindspots checklist, Tension linkage

### DIFF
--- a/css/saos-strategic.css
+++ b/css/saos-strategic.css
@@ -1072,3 +1072,138 @@ body.strategic-mode-active #strategic-workspace {
     from { transform: rotate(0deg); }
     to { transform: rotate(360deg); }
 }
+
+/* -------------------------------------------------------------------------
+ * Task 3 — "The Blindspots" rapid-fire checklist UI.
+ *
+ * Sales-psychology rationale: by styling each blindspot as a small,
+ * checklist-row chip (with a discrete remove "×" button) and giving the
+ * Add input/button row visual weight, the section reads like a punch-
+ * list rather than a journal page. The visual mass is intentionally on
+ * the Add affordance — the rep should feel mild friction every time
+ * they have NOT yet captured an outstanding discovery question.
+ * ------------------------------------------------------------------------- */
+
+.strategic-section--blindspots .blindspots-list-wrap {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.blindspots-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.375rem;
+}
+
+.blindspots-item {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.625rem;
+    padding: 0.5rem 0.75rem;
+    border-radius: 6px;
+    background: color-mix(in srgb, var(--bg-dark) 55%, transparent);
+    border: 1px solid color-mix(in srgb, var(--primary-blue) 22%, transparent);
+    color: var(--text-light);
+    font-size: 0.875rem;
+    line-height: 1.35;
+}
+
+.blindspots-item-bullet {
+    font-size: 0.875rem;
+    color: color-mix(in srgb, var(--primary-blue) 75%, var(--text-muted));
+    transform: translateY(1px);
+    flex: 0 0 auto;
+}
+
+.blindspots-item-text {
+    flex: 1 1 auto;
+    word-break: break-word;
+}
+
+.blindspots-item-remove {
+    flex: 0 0 auto;
+    width: 1.5rem;
+    height: 1.5rem;
+    border-radius: 999px;
+    border: 1px solid color-mix(in srgb, var(--text-muted) 45%, transparent);
+    background: transparent;
+    color: var(--text-muted);
+    font-size: 1rem;
+    line-height: 1;
+    cursor: pointer;
+    transition: background 150ms ease, color 150ms ease, border-color 150ms ease;
+}
+
+.blindspots-item-remove:hover,
+.blindspots-item-remove:focus-visible {
+    background: color-mix(in srgb, #ef4444 18%, transparent);
+    border-color: color-mix(in srgb, #ef4444 60%, transparent);
+    color: #fecaca;
+    outline: none;
+}
+
+.blindspots-empty {
+    padding: 0.5rem 0;
+    color: var(--text-muted);
+    font-style: italic;
+    font-size: 0.8125rem;
+}
+
+.blindspots-add-row {
+    display: flex;
+    gap: 0.5rem;
+    align-items: stretch;
+}
+
+.blindspots-add-input {
+    flex: 1 1 auto;
+    /* Inherit .strategic-field styles for borders/padding; only add the
+     * row-local layout tweaks here so the input matches surrounding
+     * textareas visually. */
+}
+
+.blindspots-add-btn {
+    flex: 0 0 auto;
+    padding: 0 1rem;
+    border-radius: 6px;
+    border: 1px solid color-mix(in srgb, var(--primary-blue) 55%, transparent);
+    background: color-mix(in srgb, var(--primary-blue) 22%, transparent);
+    color: var(--text-light);
+    font-size: 0.8125rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 150ms ease, border-color 150ms ease;
+}
+
+.blindspots-add-btn:hover,
+.blindspots-add-btn:focus-visible {
+    background: color-mix(in srgb, var(--primary-blue) 38%, transparent);
+    border-color: color-mix(in srgb, var(--primary-blue) 78%, transparent);
+    outline: none;
+}
+
+/* -------------------------------------------------------------------------
+ * Task 4 — Strategic Tension accountability prompt.
+ *
+ * Rendered as a follow-on paragraph inside the same ghost-reminder
+ * <aside> that already carries the read-only tension pills. The styling
+ * deliberately mimics a direct question (warm amber accent, slightly
+ * heavier weight) so the rep's eye lands on it before they start
+ * typing the Land & Expand strategy below.
+ * ------------------------------------------------------------------------- */
+
+.strategic-ghost-linkage-prompt {
+    margin: 0.625rem 0 0;
+    padding: 0.5rem 0.75rem;
+    border-left: 3px solid rgba(234, 179, 8, 0.7);
+    background: color-mix(in srgb, rgba(234, 179, 8, 0.18) 60%, transparent);
+    color: var(--text-light);
+    font-size: 0.8125rem;
+    line-height: 1.45;
+    font-weight: 500;
+    border-radius: 0 4px 4px 0;
+}

--- a/js/account-plan-data.js
+++ b/js/account-plan-data.js
@@ -5,7 +5,6 @@
 import {
     STRATEGIC_TENSION_GROUPS,
     PAIN_SIGNAL_PILLS,
-    CRITICAL_UNKNOWN_LANGUAGE_PILLS,
     ENTRENCHMENT_MOAT_PILLS,
 } from './account-plan-sections.js';
 
@@ -52,23 +51,44 @@ export const ENTRY_POINT_FIELD_KEYS = Object.freeze([
     // with legacy plans that pre-date the auto-stubbing flow; both are
     // written when an entry point is auto-created from a drag/drop on the
     // influence board.
+    //
+    // Field consolidation (Task 1 — Target Profile pruning):
+    //   - `operational_pain`   merges legacy `likely_pressure` +
+    //                          `what_failure_looks_like`
+    //   - `conversation_wedge` merges legacy `best_themes` +
+    //                          `narrative_openings`
+    //   - `tired_of_hearing`   deleted (low-signal fishing prompt)
+    //   - `human_context`      kept, but UI now renders it at the bottom
+    //                          of the profile (no standalone subsection)
     'contact_id',
     'contact_name',
     'why_they_matter',
-    'likely_pressure',
+    'operational_pain',
     'trust_level',
     'responsiveness',
     'political_influence',
-    'best_themes',
-    'narrative_openings',
-    'human_context',
+    'conversation_wedge',
     'mutual_connections',
-    'tired_of_hearing',
     'next_move',
     'comm_style',
     'compound_potential',
-    'what_failure_looks_like',
+    'human_context',
 ]);
+
+// Legacy entry-point field keys we still READ from saved plans so reps
+// don't lose past work. Kept out of ENTRY_POINT_FIELD_KEYS so they aren't
+// rendered as live fields; `normalizeEntryPoint` falls back to them only
+// when the merged keys are currently empty.
+const LEGACY_ENTRY_POINT_MERGE_MAP = Object.freeze({
+    operational_pain: Object.freeze(['likely_pressure', 'what_failure_looks_like']),
+    conversation_wedge: Object.freeze(['best_themes', 'narrative_openings']),
+});
+
+// Legacy entry-point fields that should be discarded entirely (no merge
+// target). `tired_of_hearing` is the only member today but the set is
+// kept extensible so future deprecations can be added without changing
+// normalizeEntryPoint.
+const LEGACY_ENTRY_POINT_DEAD_KEYS = Object.freeze(['tired_of_hearing']);
 
 export const MAX_ENTRY_POINTS = 5;
 
@@ -166,9 +186,11 @@ export function createEmptyPlan() {
                     expansion_potential: '',
                 },
                 pursuit_thesis: {
-                    core: '',
+                    // Task 2 — single merged thesis field. Replaces the
+                    // legacy `core` + `cost_of_standing_still` pair so the
+                    // section can no longer encourage duplicate prose.
+                    thesis: '',
                     why_account_matters: '',
-                    cost_of_standing_still: '',
                     timing: '',
                     executive_narrative: '',
                 },
@@ -181,9 +203,11 @@ export function createEmptyPlan() {
                     notes: '',
                 },
                 critical_unknowns: {
-                    unknowns: '',
-                    executive_language_pills: [],
-                    executive_language_notes: '',
+                    // Task 3 — "The Blindspots" rapid-fire checklist. The
+                    // section.id is preserved as `critical_unknowns` for
+                    // downstream AI/PPTX compatibility; the data shape is
+                    // now a flat string[] array of discovery questions.
+                    blindspots: [],
                 },
                 influence_mapping: {
                     executive: [],
@@ -286,23 +310,53 @@ function normalizeInfluenceContactList(value) {
 }
 
 /**
+ * Normalize the Pursuit Strategy section.
+ *
+ * Legacy fallback (Task 2 + Task 5): older plans stored two separate
+ * paragraphs under `core` and `cost_of_standing_still`. Post-
+ * consolidation, both collapse into a single `thesis` field. We stitch
+ * the two legacy paragraphs together when migrating so reps don't lose
+ * past work — the rep can edit down to a single punchy paragraph the
+ * next time they open the plan. The blank line between paragraphs is
+ * preserved so the visual break stays meaningful.
+ *
  * @param {unknown} raw
  * @param {Record<string, unknown>} sections
  */
 function normalizePursuitThesis(raw, sections) {
     const empty = createEmptyPlan().current_draft.sections.pursuit_thesis;
+
+    // Helper: stitch legacy `core` + `cost_of_standing_still` into the
+    // new `thesis` body. Both inputs may be undefined / blank — we
+    // filter before joining to avoid producing a leading blank-line
+    // artifact.
+    const mergeLegacyThesis = (rawObj) => {
+        const parts = [rawObj?.core, rawObj?.cost_of_standing_still]
+            .map((v) => (v != null ? String(v).trim() : ''))
+            .filter(Boolean);
+        return parts.join('\n\n');
+    };
+
     if (typeof raw === 'string') {
         const legacy = raw.trim() || migrateLegacySectionText(sections, 'pursuit_thesis', ['executive_summary']);
-        return legacy ? { ...empty, core: legacy } : empty;
+        return legacy ? { ...empty, thesis: legacy } : empty;
     }
     if (!isPlainObject(raw)) {
         const legacy = migrateLegacySectionText(sections, 'pursuit_thesis', ['executive_summary']);
-        return legacy ? { ...empty, core: legacy } : empty;
+        return legacy ? { ...empty, thesis: legacy } : empty;
     }
+
+    // If a `thesis` value already exists on the raw payload, keep it
+    // as-is (the rep has already migrated). Otherwise reconstruct from
+    // the legacy `core` + `cost_of_standing_still` pair so no past work
+    // is lost.
+    const thesis = raw.thesis != null && String(raw.thesis).trim()
+        ? String(raw.thesis)
+        : mergeLegacyThesis(raw);
+
     return {
-        core: raw.core != null ? String(raw.core) : '',
+        thesis,
         why_account_matters: raw.why_account_matters != null ? String(raw.why_account_matters) : '',
-        cost_of_standing_still: raw.cost_of_standing_still != null ? String(raw.cost_of_standing_still) : '',
         timing: raw.timing != null ? String(raw.timing) : '',
         executive_narrative: raw.executive_narrative != null ? String(raw.executive_narrative) : '',
     };
@@ -453,15 +507,59 @@ function normalizeLandAndExpand(raw, sections) {
 }
 
 /**
+ * Normalize a single entry-point payload to the post-consolidation
+ * schema.
+ *
+ * Sales psychology behind the legacy merge: a rep who already wrote
+ * prose into "Likely Pressure" and "What Failure Looks Like" should NOT
+ * see their work disappear because we tightened the framework. Instead
+ * we stitch those two paragraphs into the new `operational_pain` field
+ * with a blank line between them — a slightly verbose but recoverable
+ * seed that the rep can prune in 10 seconds, far better than asking
+ * them to re-author the dossier from scratch.
+ *
+ * The same logic applies to `best_themes` + `narrative_openings` →
+ * `conversation_wedge`. The dead-key `tired_of_hearing` is
+ * intentionally dropped on the floor with no fallback target — it was a
+ * low-value fishing prompt and migrating it would defeat the purpose of
+ * cutting it.
+ *
  * @param {unknown} raw
  * @returns {Record<string, string>}
  */
 function normalizeEntryPoint(raw) {
     const empty = createEmptyEntryPoint();
     if (!isPlainObject(raw)) return empty;
+
+    // 1. Copy through the canonical (post-consolidation) keys first.
+    //    Any explicit value on a new key wins over a legacy merge — a
+    //    rep who has already migrated to the new schema shouldn't have
+    //    their work overwritten by stale legacy fields.
     ENTRY_POINT_FIELD_KEYS.forEach((key) => {
         empty[key] = raw[key] != null ? String(raw[key]) : '';
     });
+
+    // 2. Backfill the merged keys from legacy sources only when the new
+    //    field is currently empty. Joining with two newlines preserves
+    //    a visual break between the originally-separate paragraphs so
+    //    the rep can see what each piece was without losing the seam.
+    Object.entries(LEGACY_ENTRY_POINT_MERGE_MAP).forEach(([targetKey, legacyKeys]) => {
+        if (empty[targetKey] && empty[targetKey].trim()) return;
+        const legacyParts = legacyKeys
+            .map((legacyKey) => (raw[legacyKey] != null ? String(raw[legacyKey]).trim() : ''))
+            .filter(Boolean);
+        if (legacyParts.length > 0) {
+            empty[targetKey] = legacyParts.join('\n\n');
+        }
+    });
+
+    // 3. Defensive cleanup: ensure no dead keys leak into the
+    //    normalized object even if a caller hand-crafted a stale
+    //    payload.
+    LEGACY_ENTRY_POINT_DEAD_KEYS.forEach((key) => {
+        if (key in empty) delete empty[key];
+    });
+
     return empty;
 }
 
@@ -533,16 +631,50 @@ function normalizePainSignals(raw) {
 }
 
 /**
+ * Normalize the (renamed) Blindspots section.
+ *
+ * Sales psychology behind the refactor: the old `unknowns` rich-text
+ * blob was where reps dumped vague anxieties — "not sure who the real
+ * decision-maker is, also not sure on budget." Converting the field
+ * into a strict string[] array forces one discrete question per line,
+ * which is exactly the granularity needed on a discovery call.
+ *
+ * Legacy fallback (Task 5): when a plan still carries the old
+ * `unknowns` rich-text blob, we split it into discrete lines and seed
+ * the new array. Markdown bullet prefixes ("-", "*", "•", "1.") are
+ * stripped so the rendered list does not double up the bullet marker.
+ * The orphaned `executive_language_notes` field is appended as
+ * additional lines if present — older plans frequently held a second
+ * unknown there. The legacy `executive_language_pills` selection is
+ * dropped intentionally; it was never a real unknown, just a tone tag.
+ *
  * @param {unknown} raw
  */
 function normalizeCriticalUnknowns(raw) {
     const empty = createEmptyPlan().current_draft.sections.critical_unknowns;
     if (!isPlainObject(raw)) return empty;
-    return {
-        unknowns: raw.unknowns != null ? String(raw.unknowns) : '',
-        executive_language_pills: normalizePillSelection(raw.executive_language_pills, CRITICAL_UNKNOWN_LANGUAGE_PILLS),
-        executive_language_notes: raw.executive_language_notes != null ? String(raw.executive_language_notes) : '',
-    };
+
+    const bulletPrefix = /^[\s]*(?:[-*\u2022]\s+|\d+[.)]\s+)/;
+    const splitToLines = (text) => String(text ?? '')
+        .split(/\r?\n+/)
+        .map((line) => line.replace(bulletPrefix, '').trim())
+        .filter(Boolean);
+
+    // Prefer an already-migrated array if present. Otherwise
+    // reconstruct from the legacy `unknowns` rich-text + tail-merge any
+    // orphaned `executive_language_notes` content so no past work is
+    // lost.
+    const rawArray = Array.isArray(raw.blindspots) ? raw.blindspots : null;
+    const blindspots = rawArray
+        ? rawArray
+            .map((entry) => (entry == null ? '' : String(entry).trim()))
+            .filter(Boolean)
+        : [
+            ...splitToLines(raw.unknowns),
+            ...splitToLines(raw.executive_language_notes),
+        ];
+
+    return { blindspots };
 }
 
 /**

--- a/js/account-plan-export-templates.js
+++ b/js/account-plan-export-templates.js
@@ -244,10 +244,19 @@ function buildExecStrategyBody(sections) {
     wrap.className = 'ap-exec-prose-stack';
 
     const data = isPlainObject(sections.pursuit_thesis) ? sections.pursuit_thesis : null;
+    // Post-Task-2: the merged `thesis` field replaces `core` +
+    // `cost_of_standing_still`. We coalesce legacy fields when the new
+    // one is empty so unmigrated plans still surface a paragraph.
+    const thesisText = data
+        ? (String(data.thesis ?? '').trim()
+            || [data.core, data.cost_of_standing_still]
+                .map((v) => String(v ?? '').trim())
+                .filter(Boolean)
+                .join('\n\n'))
+        : '';
     const blocks = data
         ? [
-            ['Core Thesis', data.core],
-            ['Cost of Standing Still', data.cost_of_standing_still],
+            ['Pursuit Thesis', thesisText],
             ['Strategic Timing', data.timing],
         ].filter(([, value]) => String(value ?? '').trim())
         : [];
@@ -1030,18 +1039,30 @@ function buildTargetProfile(rawPoint) {
     howTitle.textContent = 'The How';
     howColumn.appendChild(howTitle);
 
+    // Post-Task-1 the field set is tightened to the consolidated
+    // keys. We still fall back to legacy values when the merged field
+    // is empty so older exports continue to surface every paragraph
+    // the rep originally wrote — the data layer's normalizeEntryPoint
+    // will normally have merged these by now, but we keep the fallback
+    // in case the export is run against a raw payload.
+    const pickMerged = (mergedVal, ...legacyVals) => {
+        const merged = String(mergedVal ?? '').trim();
+        if (merged) return merged;
+        return legacyVals
+            .map((v) => String(v ?? '').trim())
+            .filter(Boolean)
+            .join('\n\n');
+    };
+
     const whyFields = [
         ['Why They Matter', rawPoint.why_they_matter],
-        ['Likely Pressure', rawPoint.likely_pressure],
-        ['What Failure Looks Like', rawPoint.what_failure_looks_like],
-        ['Human Context', rawPoint.human_context],
+        ['Operational Pain', pickMerged(rawPoint.operational_pain, rawPoint.likely_pressure, rawPoint.what_failure_looks_like)],
         ['Mutual Connections', rawPoint.mutual_connections],
+        ['Human Context', rawPoint.human_context],
     ].filter(([, val]) => String(val ?? '').trim());
 
     const howFields = [
-        ['Best Themes', rawPoint.best_themes],
-        ['Narrative Openings', rawPoint.narrative_openings],
-        ['Tired of Hearing', rawPoint.tired_of_hearing],
+        ['Conversation Wedge', pickMerged(rawPoint.conversation_wedge, rawPoint.best_themes, rawPoint.narrative_openings)],
         ['Next Move', rawPoint.next_move],
     ].filter(([, val]) => String(val ?? '').trim());
 
@@ -1469,16 +1490,38 @@ function buildDossierSectionUnits(section, sections, contacts = [], account = nu
         return [createDossierSectionBlock(section, body)];
     }
 
-    if (section.type === 'critical_unknowns') {
+    if (section.type === 'critical_unknowns' || section.type === 'blindspots_list') {
+        // Post-Task-3 the section is "The Blindspots" — a flat string
+        // array under sections.critical_unknowns.blindspots. We still
+        // accept the legacy `critical_unknowns` type alias above so an
+        // older PLAN_SECTIONS configuration would not crash the export.
         const data = isPlainObject(sections.critical_unknowns) ? sections.critical_unknowns : {};
-        const body = buildPillsAndTextExportBody(data, {
-            pillsLabel: 'Executive Language',
-            pillField: section.pillField || 'executive_language_pills',
-            textFields: section.textFields || [
-                { key: 'unknowns', hint: 'Open questions' },
-                { key: 'executive_language_notes', hint: 'Executive language notes' },
-            ],
-        });
+        const items = Array.isArray(data.blindspots)
+            ? data.blindspots
+            // Legacy fallback: split the old `unknowns` rich-text on
+            // newlines so older plans still produce bullets in the PDF.
+            : String(data.unknowns ?? '')
+                .split(/\r?\n+/)
+                .map((line) => line.replace(/^[\s]*(?:[-*\u2022]\s+|\d+[.)]\s+)/, '').trim())
+                .filter(Boolean);
+        const body = document.createElement('div');
+        body.className = 'ap-export-blindspots-body';
+        if (items.length === 0) {
+            const empty = document.createElement('p');
+            empty.className = 'ap-export-blindspots-empty';
+            empty.textContent = 'No discovery questions captured yet.';
+            body.appendChild(empty);
+        } else {
+            const list = document.createElement('ul');
+            list.className = 'ap-export-blindspots-list';
+            items.forEach((item) => {
+                const li = document.createElement('li');
+                li.className = 'ap-export-blindspots-item';
+                li.textContent = String(item ?? '').trim();
+                list.appendChild(li);
+            });
+            body.appendChild(list);
+        }
         return [createDossierSectionBlock(section, body)];
     }
 
@@ -1815,10 +1858,17 @@ function summarizePursuitThesis(value) {
     }
     if (!isPlainObject(value)) return 'No pursuit thesis captured yet.';
 
+    // Post-Task-2: prefer the merged `thesis` field but stitch the
+    // legacy `core` + `cost_of_standing_still` together when needed so
+    // older plans still produce a non-empty summary block.
+    const thesisText = String(value.thesis ?? '').trim()
+        || [value.core, value.cost_of_standing_still]
+            .map((v) => String(v ?? '').trim())
+            .filter(Boolean)
+            .join('\n\n');
     const parts = [
-        value.core ? `Core Thesis: ${String(value.core).trim()}` : '',
+        thesisText ? `Pursuit Thesis: ${thesisText}` : '',
         value.why_account_matters ? `Why This Account Matters: ${String(value.why_account_matters).trim()}` : '',
-        value.cost_of_standing_still ? `Cost of Standing Still: ${String(value.cost_of_standing_still).trim()}` : '',
         value.timing ? `Strategic Timing: ${String(value.timing).trim()}` : '',
         value.executive_narrative ? `Executive Narrative: ${String(value.executive_narrative).trim()}` : '',
     ].filter(Boolean);

--- a/js/account-plan-presentation-ai.js
+++ b/js/account-plan-presentation-ai.js
@@ -263,19 +263,27 @@ function fallbackPainSignalBullets(sections) {
  */
 function fallbackCriticalUnknownBullets(sections) {
     const unknowns = isPlainObject(sections.critical_unknowns) ? sections.critical_unknowns : {};
-    const pills = Array.isArray(unknowns.executive_language_pills)
-        ? unknowns.executive_language_pills
-        : [];
+    // Post-Task-3 the section stores `blindspots: string[]`. The
+    // legacy `unknowns` rich-text blob (and the now-deprecated
+    // executive_language_* fields) are still consulted as a fallback so
+    // a half-migrated plan continues to render bullets — see
+    // normalizeCriticalUnknowns in account-plan-data.js for the
+    // equivalent migration path on the data layer.
+    const arr = Array.isArray(unknowns.blindspots) ? unknowns.blindspots : null;
+    if (arr && arr.length > 0) {
+        return arr
+            .map((entry) => String(entry ?? '').trim())
+            .filter(Boolean)
+            .slice(0, 3);
+    }
     const lines = extractBulletLines(unknowns.unknowns);
-    const bullets = [
+    return [
         ...lines,
-        ...pills.map((pill) => String(pill ?? '').trim()).filter(Boolean),
         String(unknowns.executive_language_notes ?? '').trim(),
     ]
         .map((line) => String(line).trim())
         .filter(Boolean)
         .slice(0, 3);
-    return bullets;
 }
 
 /**
@@ -283,10 +291,17 @@ function fallbackCriticalUnknownBullets(sections) {
  */
 function fallbackPursuitBullets(sections) {
     const thesis = isPlainObject(sections.pursuit_thesis) ? sections.pursuit_thesis : {};
+    // Post-Task-2 the single `thesis` field replaces legacy `core` +
+    // `cost_of_standing_still`. We coalesce in that order so a
+    // half-migrated payload still surfaces SOMETHING in the bullets.
+    const merged = String(thesis.thesis ?? '').trim()
+        || [thesis.core, thesis.cost_of_standing_still]
+            .map((v) => String(v ?? '').trim())
+            .filter(Boolean)
+            .join(' — ');
     return [
-        thesis.core,
+        merged,
         thesis.why_account_matters,
-        thesis.cost_of_standing_still,
         thesis.timing,
     ]
         .map((v) => String(v ?? '').trim())
@@ -497,8 +512,15 @@ function pickEntryPoints(raw, sections) {
         .slice(0, 2)
         .map((p) => ({
             name: String(p.contact_name).trim(),
-            headline: String(p.why_they_matter ?? p.likely_pressure ?? 'Key influencer').trim().slice(0, 80),
-            hook: String(p.next_move ?? p.narrative_openings ?? '').trim().slice(0, 100),
+            // Headline prefers the structured `why_they_matter` field;
+            // post-Task-1 we also fall back to the merged
+            // `operational_pain` (and the legacy `likely_pressure` for
+            // un-migrated payloads).
+            headline: String(p.why_they_matter ?? p.operational_pain ?? p.likely_pressure ?? 'Key influencer').trim().slice(0, 80),
+            // Hook prefers the explicit `next_move`. The legacy
+            // `narrative_openings` and the new merged `conversation_wedge`
+            // are consulted as fallbacks.
+            hook: String(p.next_move ?? p.conversation_wedge ?? p.narrative_openings ?? '').trim().slice(0, 100),
             badges: [
                 p.trust_level ? `Trust: ${p.trust_level}` : '',
                 p.political_influence ? `Influence: ${p.political_influence}` : '',

--- a/js/account-plan-sections.js
+++ b/js/account-plan-sections.js
@@ -2,7 +2,7 @@
  * Strategic Account OS — section registry (canvas, TOC, export metadata).
  */
 
-/** @typedef {'account_snapshot' | 'composite_textarea' | 'pills_and_narrative' | 'influence_board' | 'psychology_grid' | 'momentum' | 'timeline_view' | 'triple_textarea' | 'entry_point_carousel' | 'critical_unknowns' | 'entrenchment' | 'pain_signals' | 'white_space_matrix' | 'interaction_log'} PlanSectionType */
+/** @typedef {'account_snapshot' | 'composite_textarea' | 'pills_and_narrative' | 'influence_board' | 'psychology_grid' | 'momentum' | 'timeline_view' | 'triple_textarea' | 'entry_point_carousel' | 'critical_unknowns' | 'blindspots_list' | 'entrenchment' | 'pain_signals' | 'white_space_matrix' | 'interaction_log'} PlanSectionType */
 
 /** @typedef {'none' | 'lead' | 'block'} SectionContextMode */
 
@@ -191,6 +191,53 @@ export const POSITIONING_PILLS = Object.freeze([
  */
 export const TENSION_GHOST_SECTIONS = Object.freeze(['plan_30_60_90', 'land_and_expand']);
 
+// ---------------------------------------------------------------------------
+// Task 4 — Strategic Tension accountability prompt
+// ---------------------------------------------------------------------------
+// Sales psychology: when a tension is selected on the Strategic Tensions
+// section (e.g. "Cloud" over "Control"), reps typically forget about that
+// choice by the time they're drafting the Land & Expand strategy. The plan
+// then drifts into a generic "build trust, expand footprint" template that
+// could apply to any account.
+//
+// To force the rep to wire the tension THROUGH the solution, we render a
+// short, direct prompt above the Land & Expand textareas whenever any
+// strategic tension pill is active. The prompt is data-driven (this map)
+// so future sections can be linked declaratively without touching the UI
+// rendering code.
+// ---------------------------------------------------------------------------
+
+/**
+ * Section IDs that should display the contextual "How does this resolve
+ * the identified tension?" prompt above their primary edit surface, keyed
+ * by the human-readable section label used inside the prompt template.
+ *
+ * @type {Readonly<Record<string, string>>}
+ */
+export const TENSION_LINKAGE_PROMPTS = Object.freeze({
+    land_and_expand: 'Land & Expand',
+});
+
+/**
+ * Build the contextual prompt sentence shown above a tension-linked
+ * section. Centralized here so AI/export layers can reuse the exact same
+ * phrasing if they ever want to forward this insight into a slide deck.
+ *
+ * @param {string} sectionLabel — pretty label, e.g. 'Land & Expand'
+ * @param {string[]} selectedTensions — array of pill values (already
+ *   filtered to truthy strings by the caller)
+ * @returns {string}
+ */
+export function buildTensionLinkagePromptText(sectionLabel, selectedTensions) {
+    const list = (selectedTensions || []).filter(Boolean);
+    if (list.length === 0) return '';
+    // Single tension → name it directly. Multiple → comma-join in
+    // selection order so the rep visually pairs the prompt back to the
+    // pill row above.
+    const joined = list.length === 1 ? list[0] : list.join(', ');
+    return `How does our ${sectionLabel} strategy resolve your identified tension: ${joined}?`;
+}
+
 /**
  * Sections whose composite textareas should display the soft "Insight Density"
  * border cue once a single box exceeds the synthesize-or-cut threshold below.
@@ -239,6 +286,24 @@ export const ENTRY_POINT_LEVEL_OPTIONS = Object.freeze(['', 'Low', 'Medium', 'Hi
 /** @type {readonly string[]} */
 export const ENTRY_POINT_COMM_STYLES = Object.freeze(['', 'Concise', 'Strategic', 'Conversational', 'Analytical']);
 
+// ---------------------------------------------------------------------------
+// Target Profile (Entry Point) export labels — post-consolidation
+// ---------------------------------------------------------------------------
+// Sales psychology: the previous 9-textarea interrogation generated
+// framework fatigue. Reps were answering the same question (operational
+// pain) twice under different banners ("Likely Pressure" + "What Failure
+// Looks Like"), and similarly for narrative angles ("Best Themes" +
+// "Narrative Openings"). The merged keys force a single, sharper answer
+// per dimension — which is what an executive actually responds to in a
+// discovery call.
+//
+// `tired_of_hearing` is gone entirely. It was a fishing prompt that
+// yielded "vendor pitches" 90% of the time and never made it into a
+// real strategy. `human_context` is preserved but is now rendered at
+// the bottom of the profile UI rather than in its own "Human
+// Intelligence" subsection.
+// ---------------------------------------------------------------------------
+
 /** @type {readonly { key: string, label: string }[]} */
 export const ENTRY_POINT_EXPORT_LABELS = Object.freeze([
     { key: 'trust_level', label: 'Trust Level' },
@@ -247,14 +312,15 @@ export const ENTRY_POINT_EXPORT_LABELS = Object.freeze([
     { key: 'comm_style', label: 'Comm Style' },
     { key: 'compound_potential', label: 'Compound Potential' },
     { key: 'why_they_matter', label: 'Why They Matter' },
-    { key: 'likely_pressure', label: 'Likely Pressure' },
-    { key: 'what_failure_looks_like', label: 'What Failure Looks Like' },
-    { key: 'best_themes', label: 'Best Themes' },
-    { key: 'narrative_openings', label: 'Narrative Openings' },
-    { key: 'tired_of_hearing', label: 'Tired of Hearing' },
+    // Merge of legacy `likely_pressure` + `what_failure_looks_like`.
+    { key: 'operational_pain', label: 'Operational Pain' },
+    // Merge of legacy `best_themes` + `narrative_openings`.
+    { key: 'conversation_wedge', label: 'Conversation Wedge' },
     { key: 'next_move', label: 'Next Move' },
-    { key: 'human_context', label: 'Human Context' },
     { key: 'mutual_connections', label: 'Mutual Connections' },
+    // Relocated — now appended at the bottom of the individual Target
+    // Profile UI as a final colour-commentary field.
+    { key: 'human_context', label: 'Human Context' },
 ]);
 
 /**
@@ -302,25 +368,41 @@ export const PLAN_SECTIONS = Object.freeze([
         exportExec: true,
     },
     {
+        // ----------------------------------------------------------------
+        // Pursuit Strategy (Task 2 — consolidation)
+        // ----------------------------------------------------------------
+        // Sales psychology behind the merge: in infrastructure / telecom
+        // pursuits, the "core thesis" and the "cost of standing still"
+        // are almost never two distinct stories — the thesis IS the pain
+        // of inaction. Splitting them into two boxes encouraged reps to
+        // produce duplicate prose (often a near-verbatim restatement)
+        // and diluted the message that downstream AI and PPTX engines
+        // try to synthesize.
+        //
+        // The merged `thesis` field is intentionally framed as a single
+        // forcing question — "Why is their status quo broken, and why
+        // are we the only logical fix right now?" — to compel a sharper,
+        // more confrontational answer.
+        //
+        // `why_account_matters`, `timing`, and `executive_narrative` are
+        // preserved because they answer materially different questions
+        // (account selection, trigger events, and executive language)
+        // that a thesis box on its own cannot.
+        // ----------------------------------------------------------------
         id: 'pursuit_thesis',
         type: 'composite_textarea',
         title: 'Pursuit Strategy',
         contextMode: 'none',
         fields: [
             {
-                key: 'core',
-                label: 'Core Thesis',
-                hint: 'Why they might change — operational pain, executive pressure, vendor dissatisfaction, cloud modernization.',
+                key: 'thesis',
+                label: 'Pursuit Thesis',
+                hint: 'Why is their status quo broken, and why are we the only logical fix right now?',
             },
             {
                 key: 'why_account_matters',
                 label: 'Why This Account Matters',
                 hint: 'Strategic importance to our business — logo, reference, expansion, or competitive displacement.',
-            },
-            {
-                key: 'cost_of_standing_still',
-                label: 'Cost of Standing Still',
-                hint: 'Fragility, scaling bottlenecks, and accumulating tech debt.',
             },
             {
                 key: 'timing',
@@ -363,17 +445,29 @@ export const PLAN_SECTIONS = Object.freeze([
         exportExec: false,
     },
     {
+        // ----------------------------------------------------------------
+        // The Blindspots (Task 3 — formerly "Critical Unknowns")
+        // ----------------------------------------------------------------
+        // Sales psychology behind this refactor: a giant paragraph
+        // textarea for "what we don't know" is a fluff trap. Reps either
+        // leave it blank or write meandering anxieties. By forcing each
+        // unknown into a single line in a rapid-fire bulleted list —
+        // with an explicit Add button — we get a discovery-call
+        // checklist instead of a journal entry. The UI shape ("a strict
+        // checklist of questions they must answer on their next
+        // discovery call") is designed to feel actionable, not academic.
+        //
+        // We deliberately keep section.id === 'critical_unknowns' for
+        // downstream compatibility (AI engine, PPTX, exports). The
+        // user-facing rename to "The Blindspots" lives in the title
+        // field, and the data shape under sections.critical_unknowns
+        // collapses to { blindspots: string[] }.
+        // ----------------------------------------------------------------
         id: 'critical_unknowns',
-        type: 'critical_unknowns',
-        title: 'Critical Unknowns',
+        type: 'blindspots_list',
+        title: 'The Blindspots',
         contextMode: 'lead',
-        description: 'What we still need to learn before advancing the pursuit.',
-        pills: CRITICAL_UNKNOWN_LANGUAGE_PILLS,
-        pillField: 'executive_language_pills',
-        textFields: [
-            { key: 'unknowns', hint: 'Open questions and intelligence gaps.' },
-            { key: 'executive_language_notes', hint: 'How executives frame uncertainty.' },
-        ],
+        description: 'A strict checklist of questions you must answer on your next discovery call.',
         exportDossier: true,
         exportExec: false,
     },

--- a/js/account-plan-ui.js
+++ b/js/account-plan-ui.js
@@ -21,6 +21,8 @@ import {
     PSYCHOLOGY_GRAVITY_PILLS,
     STRATEGIC_TENSION_GROUPS,
     TENSION_GHOST_SECTIONS,
+    TENSION_LINKAGE_PROMPTS,
+    buildTensionLinkagePromptText,
     INSIGHT_DENSITY_SECTIONS,
     INSIGHT_DENSITY_SOFT_LIMIT,
 } from './account-plan-sections.js';
@@ -503,6 +505,63 @@ function buildFieldHintHtml(hint) {
  * @param {{ key: string, label?: string, hint?: string }} field
  * @param {unknown} rawValue
  */
+/**
+ * Build the rapid-fire "Blindspots" list UI (Task 3). The data shape is
+ * a flat string[] under sections.critical_unknowns.blindspots — see the
+ * Task 3 commentary in account-plan-data.js for the rename rationale.
+ *
+ * @param {import('./account-plan-sections.js').PlanSectionDef} section
+ * @param {Record<string, unknown>} data
+ */
+function buildBlindspotsListHtml(section, data) {
+    const obj = isPlainObject(data) ? data : {};
+    const items = Array.isArray(obj.blindspots) ? obj.blindspots : [];
+    const inputId = `blindspots-input-${section.id}`;
+
+    // Each row is keyed by its index so the surrounding canvas re-render
+    // (refreshBlindspotsSection) can rebuild the list cheaply. We use
+    // <button type="button"> for remove so the Enter-key handler on
+    // the input doesn't accidentally trigger a row removal.
+    const rowsHtml = items.length > 0
+        ? items.map((entry, index) => {
+            const text = String(entry ?? '').trim();
+            if (!text) return '';
+            return `
+                <li class="blindspots-item" data-blindspots-index="${index}">
+                    <span class="blindspots-item-bullet" aria-hidden="true">▢</span>
+                    <span class="blindspots-item-text">${escapeHtml(text)}</span>
+                    <button
+                        type="button"
+                        class="blindspots-item-remove"
+                        data-blindspots-remove="${index}"
+                        aria-label="Remove blindspot: ${escapeHtml(text)}"
+                    >×</button>
+                </li>`;
+        }).join('')
+        : `<li class="blindspots-empty">Add the open questions you must answer on your next discovery call.</li>`;
+
+    return `
+        <div class="blindspots-list-wrap" data-blindspots-host>
+            <ul class="blindspots-list" role="list">${rowsHtml}</ul>
+            <div class="blindspots-add-row">
+                <label class="sr-only" for="${inputId}">Add a blindspot</label>
+                <input
+                    type="text"
+                    id="${inputId}"
+                    class="strategic-field blindspots-add-input"
+                    data-blindspots-input
+                    placeholder="One question per line — e.g. Who actually signs the SOW?"
+                    autocomplete="off"
+                />
+                <button
+                    type="button"
+                    class="blindspots-add-btn"
+                    data-blindspots-add
+                >Add</button>
+            </div>
+        </div>`;
+}
+
 function buildCompositeFieldHtml(sectionId, field, rawValue) {
     const rawString = String(rawValue ?? '');
     const value = escapeHtml(rawString);
@@ -655,10 +714,20 @@ function resolveTensionGhostPair(pill) {
  * Split out so refresh can swap the body without touching the host element
  * itself.
  *
+ * The optional `hostSectionId` parameter is used to look up an opt-in
+ * "tension linkage" prompt (Task 4). When the host section is registered
+ * in TENSION_LINKAGE_PROMPTS we append a directive question that forces
+ * the rep to wire their selected tensions THROUGH the strategy below —
+ * e.g. "How does our Land & Expand strategy resolve your identified
+ * tension: Cloud?". Without this nudge reps habitually default to
+ * generic "build trust, expand footprint" prose that ignores the
+ * tension they just picked one section above.
+ *
  * @param {unknown} tensions
+ * @param {string} [hostSectionId]
  * @returns {string}
  */
-function buildStrategicTensionGhostInner(tensions) {
+function buildStrategicTensionGhostInner(tensions, hostSectionId = '') {
     const rawPills = isPlainObject(tensions) && Array.isArray(tensions.selected_pills)
         ? tensions.selected_pills
         : [];
@@ -690,9 +759,25 @@ function buildStrategicTensionGhostInner(tensions) {
         return `<span class="strategic-ghost-pill"><strong>${escapeHtml(pair.chosen)}</strong>${altSuffix}</span>`;
     }).join('');
 
+    // Task 4 — accountability prompt. Centralized in
+    // buildTensionLinkagePromptText so AI/export layers can reuse the
+    // exact phrasing later if they want to surface this prompt in a
+    // slide deck. We render it as a follow-on paragraph inside the same
+    // <aside> so the existing refresh path keeps it in sync.
+    const linkageSectionLabel = hostSectionId
+        ? (TENSION_LINKAGE_PROMPTS && TENSION_LINKAGE_PROMPTS[hostSectionId]) || ''
+        : '';
+    const linkagePromptText = linkageSectionLabel
+        ? buildTensionLinkagePromptText(linkageSectionLabel, pairs.map((p) => p.chosen))
+        : '';
+    const linkagePromptHtml = linkagePromptText
+        ? `<p class="strategic-ghost-linkage-prompt" data-tension-linkage-host="${escapeHtml(hostSectionId)}">${escapeHtml(linkagePromptText)}</p>`
+        : '';
+
     return `
         <p class="strategic-ghost-headline">${headline}</p>
-        <div class="strategic-ghost-pills">${pillsHtml}</div>`;
+        <div class="strategic-ghost-pills">${pillsHtml}</div>
+        ${linkagePromptHtml}`;
 }
 
 /**
@@ -711,7 +796,7 @@ function buildStrategicTensionGhostHtml(tensions, hostSectionId) {
             data-tension-ghost-host="${escapeHtml(hostSectionId)}"
             aria-live="polite"
             aria-label="Strategic tensions reminder"
-        >${buildStrategicTensionGhostInner(tensions)}</aside>`;
+        >${buildStrategicTensionGhostInner(tensions, hostSectionId)}</aside>`;
 }
 
 /**
@@ -724,7 +809,11 @@ function refreshStrategicTensionGhosts() {
     const tensions = _liveSections.strategic_tensions;
     document.querySelectorAll('[data-tension-ghost-host]').forEach((host) => {
         if (!(host instanceof HTMLElement)) return;
-        host.innerHTML = buildStrategicTensionGhostInner(tensions);
+        // Forward the section ID so the linkage prompt (Task 4) keeps
+        // its phrasing in sync as the host changes (e.g. if we add more
+        // linkage-enabled sections in the future).
+        const hostSectionId = host.dataset.tensionGhostHost || '';
+        host.innerHTML = buildStrategicTensionGhostInner(tensions, hostSectionId);
     });
 }
 
@@ -923,6 +1012,11 @@ function buildCompositeTextareaHtml(section, data) {
     const fields = section.fields || [];
     return `<div class="strategic-composite-grid">${fields.map((field) => {
         const fieldHtml = buildCompositeFieldHtml(section.id, field, obj[field.key]);
+        // The executive_narrative box pairs with a row of hint pills
+        // (Growth / Resiliency / Modernization / …). The pills are
+        // anchored to that specific subfield, so the special case is
+        // unchanged post-Task-2 — only the surrounding `thesis` field
+        // changed identity.
         if (section.id === 'pursuit_thesis' && field.key === 'executive_narrative') {
             return `${fieldHtml}${buildExecutiveNarrativeHintPillsHtml()}`;
         }
@@ -1362,24 +1456,21 @@ function buildEntryPointCardHtml(point, index, contacts, isActive) {
                 <h5 class="entry-point-row-panel-title">Strategic Context</h5>
                 <div class="entry-point-grid entry-point-grid--why">
                     ${buildEntryPointTextarea(String(index), 'why_they_matter', 'Why They Matter', String(data.why_they_matter ?? ''), 'Strategic relevance and decision weight.')}
-                    ${buildEntryPointTextarea(String(index), 'likely_pressure', 'Likely Pressure', String(data.likely_pressure ?? ''), 'What keeps them up at night.')}
-                    ${buildEntryPointTextarea(String(index), 'what_failure_looks_like', 'What Failure Looks Like', String(data.what_failure_looks_like ?? ''), 'Risk if this entry point stalls.')}
+                    ${buildEntryPointTextarea(String(index), 'operational_pain', 'Operational Pain', String(data.operational_pain ?? ''), 'What keeps them up at night AND what happens if this stalls — one tight paragraph.')}
                 </div>
             </div>
             <div class="entry-point-row-panel entry-point-row-panel--how">
                 <h5 class="entry-point-row-panel-title">Narrative &amp; Approach</h5>
                 <div class="entry-point-grid entry-point-grid--how">
-                    ${buildEntryPointTextarea(String(index), 'best_themes', 'Best Themes', String(data.best_themes ?? ''), 'Messaging angles that resonate.')}
-                    ${buildEntryPointTextarea(String(index), 'narrative_openings', 'Narrative Openings', String(data.narrative_openings ?? ''), 'How to open the conversation.')}
-                    ${buildEntryPointTextarea(String(index), 'tired_of_hearing', 'Tired of Hearing', String(data.tired_of_hearing ?? ''), 'Pitches or claims to avoid.')}
+                    ${buildEntryPointTextarea(String(index), 'conversation_wedge', 'Conversation Wedge', String(data.conversation_wedge ?? ''), 'One sharp angle to open the conversation — the message they will actually lean into.')}
                     ${buildEntryPointTextarea(String(index), 'next_move', 'Next Move', String(data.next_move ?? ''), 'Concrete next action.')}
+                    ${buildEntryPointTextarea(String(index), 'mutual_connections', 'Mutual Connections', String(data.mutual_connections ?? ''), 'Shared relationships or references.')}
                 </div>
             </div>
             <div class="entry-point-row-panel entry-point-row-panel--human">
-                <h5 class="entry-point-row-panel-title">Human Intelligence</h5>
-                <div class="entry-point-grid entry-point-grid--human">
-                    ${buildEntryPointTextarea(String(index), 'human_context', 'Human Context', String(data.human_context ?? ''), 'Personal motivations and style cues.')}
-                    ${buildEntryPointTextarea(String(index), 'mutual_connections', 'Mutual Connections', String(data.mutual_connections ?? ''), 'Shared relationships or references.')}
+                <h5 class="entry-point-row-panel-title">Human Context</h5>
+                <div class="entry-point-grid entry-point-grid--human-context">
+                    ${buildEntryPointTextarea(String(index), 'human_context', 'Human Context', String(data.human_context ?? ''), 'Personal motivations and style cues — the colour commentary that closes the loop.')}
                 </div>
             </div>
         </div>`;
@@ -2897,13 +2988,11 @@ function buildCanvasHtml(sections, entryPointActiveIndex = 0) {
             );
         }
 
-        if (section.type === 'pain_signals' || section.type === 'critical_unknowns' || section.type === 'entrenchment') {
+        if (section.type === 'pain_signals' || section.type === 'entrenchment') {
             const data = isPlainObject(sections[section.id]) ? sections[section.id] : {};
-            const extraClass = section.type === 'critical_unknowns'
-                ? 'strategic-section--critical-unknowns'
-                : section.type === 'entrenchment'
-                    ? 'strategic-section--entrenchment'
-                    : 'strategic-section--pain-signals';
+            const extraClass = section.type === 'entrenchment'
+                ? 'strategic-section--entrenchment'
+                : 'strategic-section--pain-signals';
             return wrapStrategicSection(
                 sectionId,
                 headingId,
@@ -2911,6 +3000,21 @@ function buildCanvasHtml(sections, entryPointActiveIndex = 0) {
                 headerContext,
                 buildPillsAndNarrativeHtml(section, data),
                 extraClass
+            );
+        }
+
+        // Task 3 — "The Blindspots" dedicated branch. The legacy
+        // critical_unknowns section.type was pills+narrative; the new
+        // blindspots_list type renders a focused checklist instead.
+        if (section.type === 'blindspots_list') {
+            const data = isPlainObject(sections[section.id]) ? sections[section.id] : {};
+            return wrapStrategicSection(
+                sectionId,
+                headingId,
+                section.title,
+                headerContext,
+                buildBlindspotsListHtml(section, data),
+                'strategic-section--blindspots'
             );
         }
 
@@ -3111,10 +3215,15 @@ function isSectionFilled(section, sections) {
         return fields.some((field) => String(obj[field.key] ?? '').trim());
     }
 
+    if (section.type === 'blindspots_list') {
+        const obj = isPlainObject(data) ? data : {};
+        const items = Array.isArray(obj.blindspots) ? obj.blindspots : [];
+        return items.some((entry) => String(entry ?? '').trim());
+    }
+
     if (
         section.type === 'pills_and_narrative'
         || section.type === 'pain_signals'
-        || section.type === 'critical_unknowns'
         || section.type === 'entrenchment'
     ) {
         const obj = isPlainObject(data) ? data : {};
@@ -3501,6 +3610,88 @@ function updateRailSummaries(sections) {
 
 let _draggedInfluenceContactId = null;
 
+/**
+ * Push a new blindspot string into the live plan, persist, and re-render
+ * just the section. Trimmed empties and exact-match duplicates are
+ * silently dropped because a strict checklist UI must NOT accumulate
+ * noise — the whole point of the refactor is to keep the list short.
+ *
+ * @param {string} text
+ */
+function addBlindspotEntry(text) {
+    if (!_liveSections) return;
+    const trimmed = String(text || '').trim();
+    if (!trimmed) return;
+    const current = isPlainObject(_liveSections.critical_unknowns)
+        ? _liveSections.critical_unknowns
+        : { blindspots: [] };
+    const existing = Array.isArray(current.blindspots) ? current.blindspots : [];
+    if (existing.some((entry) => String(entry ?? '').trim() === trimmed)) {
+        // Silent dedupe — the rep typed the same question twice. Toasting
+        // would be noisy; the input clearing below is signal enough.
+        return;
+    }
+    _liveSections.critical_unknowns = {
+        blindspots: [...existing, trimmed],
+    };
+    refreshBlindspotsSection();
+    updateRailSummaries(_liveSections);
+    queueAutosave();
+}
+
+/**
+ * Remove a blindspot at the given index. Used by the per-row "×" remove
+ * button. Out-of-range indices are ignored defensively because the
+ * caller is reading dataset attributes off potentially-stale DOM.
+ *
+ * @param {number} index
+ */
+function removeBlindspotEntry(index) {
+    if (!_liveSections || !Number.isFinite(index)) return;
+    const current = isPlainObject(_liveSections.critical_unknowns)
+        ? _liveSections.critical_unknowns
+        : { blindspots: [] };
+    const existing = Array.isArray(current.blindspots) ? [...current.blindspots] : [];
+    if (index < 0 || index >= existing.length) return;
+    existing.splice(index, 1);
+    _liveSections.critical_unknowns = { blindspots: existing };
+    refreshBlindspotsSection();
+    updateRailSummaries(_liveSections);
+    queueAutosave();
+}
+
+/**
+ * Re-render just the Blindspots section in place. We intentionally do
+ * NOT call paintCanvas() — that would steal caret focus from any other
+ * field the rep is editing. The Blindspots input is not stateful
+ * between renders (it's an ephemeral add buffer) so a hard innerHTML
+ * swap is safe here.
+ */
+function refreshBlindspotsSection() {
+    const sectionEl = document.getElementById('strategic-section-critical_unknowns');
+    const sectionDef = PLAN_SECTIONS.find((section) => section.id === 'critical_unknowns');
+    if (!sectionEl || !sectionDef || !_liveSections) return;
+
+    const headingId = `strategic-heading-${sectionDef.id}`;
+    const headerContext = buildSectionHeaderContext(sectionDef);
+    const data = isPlainObject(_liveSections.critical_unknowns)
+        ? _liveSections.critical_unknowns
+        : { blindspots: [] };
+    const bodyHtml = buildBlindspotsListHtml(sectionDef, data);
+
+    sectionEl.innerHTML = `
+        <h4 id="${headingId}" class="strategic-section-title">${escapeHtml(sectionDef.title)}</h4>
+        ${headerContext.leadHtml}
+        ${headerContext.blockHtml}
+        ${bodyHtml}`;
+
+    // Re-focus the input so the rep can keep typing successive
+    // blindspots without re-clicking. This mirrors the "rapid-fire"
+    // checklist feel called for in the Task 3 spec.
+    const input = sectionEl.querySelector('[data-blindspots-input]');
+    if (input instanceof HTMLInputElement) input.focus();
+}
+
 function bindCanvasFormEvents(canvas) {
     if (_canvasEventsBound) return;
     _canvasEventsBound = true;
@@ -3549,9 +3740,47 @@ function bindCanvasFormEvents(canvas) {
         queueAutosave();
     });
 
+    // Task 3 — Enter key inside the Blindspots input fires the same
+    // add-flow as clicking the Add button. We bind keydown (not keypress)
+    // so the handler also fires inside IME composition modes — though we
+    // skip composing events so Asian-language input doesn't eat half a
+    // character.
+    canvas.addEventListener('keydown', (event) => {
+        if (event.key !== 'Enter') return;
+        const target = event.target;
+        if (!(target instanceof HTMLInputElement)) return;
+        if (!target.matches('[data-blindspots-input]')) return;
+        if (event.isComposing) return;
+        event.preventDefault();
+        const value = target.value;
+        target.value = '';
+        addBlindspotEntry(value);
+    });
+
     canvas.addEventListener('click', (event) => {
         const target = event.target;
         if (!(target instanceof Element)) return;
+
+        // Task 3 — Blindspots Add / Remove buttons.
+        const blindspotAdd = target.closest('[data-blindspots-add]');
+        if (blindspotAdd instanceof HTMLElement) {
+            event.preventDefault();
+            const host = blindspotAdd.closest('[data-blindspots-host]');
+            const input = host?.querySelector('[data-blindspots-input]');
+            if (input instanceof HTMLInputElement) {
+                const value = input.value;
+                input.value = '';
+                addBlindspotEntry(value);
+            }
+            return;
+        }
+
+        const blindspotRemove = target.closest('[data-blindspots-remove]');
+        if (blindspotRemove instanceof HTMLElement) {
+            event.preventDefault();
+            removeBlindspotEntry(Number(blindspotRemove.dataset.blindspotsRemove));
+            return;
+        }
 
         const entryPointPill = target.closest('.entry-point-pill');
         if (entryPointPill instanceof HTMLElement) {

--- a/tests/e2e/accounts.functional.spec.ts
+++ b/tests/e2e/accounts.functional.spec.ts
@@ -86,7 +86,11 @@ test.describe('Strategic Account OS', () => {
     await createAndSelectAccount(page, acc);
     await acc.switchToStrategicMode();
 
-    const textarea = acc.strategicTextarea('pursuit_thesis.core');
+    // Post-Task-2 the pursuit_thesis.core + cost_of_standing_still pair
+    // collapsed into a single `pursuit_thesis.thesis` textarea. The
+    // selector follows the new data-field path produced by the canvas
+    // renderer.
+    const textarea = acc.strategicTextarea('pursuit_thesis.thesis');
     await textarea.waitFor({ state: 'visible', timeout: 15_000 });
 
     guardian.step('Typing into Pursuit Thesis textarea');
@@ -162,7 +166,8 @@ test.describe('Strategic Account OS', () => {
     await createAndSelectAccount(page, acc);
     await acc.switchToStrategicMode();
 
-    const textarea = acc.strategicTextarea('pursuit_thesis.core');
+    // Post-Task-2 selector — see autosave test above for rationale.
+    const textarea = acc.strategicTextarea('pursuit_thesis.thesis');
     await textarea.waitFor({ state: 'visible', timeout: 15_000 });
     await textarea.fill(`E2E force commit ${Date.now()}`);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Strategic Accounts reps were experiencing framework fatigue from redundant questions and overly academic text fields. This PR aggressively prunes, merges, and tightens the data schema and UI so the framework forces high-impact, actionable strategies without the fluff.

All changes are heavily commented in-file with the sales psychology behind each consolidation.

## What changed

### Task 1 — Target Profile (Entry Points) consolidation
- Merged `likely_pressure` + `what_failure_looks_like` → `operational_pain` (one tighter paragraph).
- Merged `best_themes` + `narrative_openings` → `conversation_wedge` (one sharper angle).
- Deleted `tired_of_hearing` entirely (low-signal fishing prompt — reps default to "vendor pitches" 90% of the time).
- Relocated `human_context` from its orphaned "Human Intelligence" subsection to a single field at the bottom of the profile card.

### Task 2 — Pursuit Strategy condensation
- Merged `core` + `cost_of_standing_still` → single `thesis` textarea titled "Pursuit Thesis".
- Placeholder is now a forcing question: _"Why is their status quo broken, and why are we the only logical fix right now?"_
- Preserves `why_account_matters`, `timing`, and `executive_narrative` (different questions, different answers).

### Task 3 — "Critical Unknowns" → "The Blindspots"
- Section title renamed; section.id kept as `critical_unknowns` for downstream AI/PPTX/export back-compat.
- Data shape changed from a single rich-text blob (`unknowns: string`) to a strict `blindspots: string[]` array.
- New UI: list of removeable chips + Add button + Enter-to-add input, focused on rapid checklist capture rather than journal prose.

### Task 4 — Strategic Tension accountability prompt
- When any tension pill is selected, the ghost reminder above **Land & Expand** appends a directive question:  
  _"How does our Land & Expand strategy resolve your identified tension: [Selected Tension]?"_
- Driven by a new declarative `TENSION_LINKAGE_PROMPTS` map in `account-plan-sections.js` so additional sections can opt in without touching the UI rendering code.

### Task 5 — Safe data handling
- `normalizeEntryPoint` stitches legacy `likely_pressure` + `what_failure_looks_like` (and the narrative pair) into the merged fields when migrating older plan documents.
- `normalizePursuitThesis` stitches legacy `core` + `cost_of_standing_still` into the new `thesis` field.
- `normalizeCriticalUnknowns` splits the legacy `unknowns` rich-text blob into discrete `blindspots` bullets (markdown bullet prefixes stripped).
- Downstream readers (AI presentation, PDF/PPTX export, e2e tests) consult new keys first and fall back to legacy keys, so half-migrated payloads never blow up the render path — reps never lose past work.

## Files touched

| File | Why |
| --- | --- |
| `js/account-plan-data.js` | New field schema + legacy fallbacks for all four merges |
| `js/account-plan-sections.js` | Section registry updates + `TENSION_LINKAGE_PROMPTS` config |
| `js/account-plan-ui.js` | Entry-point card layout, Blindspots list UI, tension linkage prompt |
| `js/account-plan-export-templates.js` | PDF dossier readers (merged thesis + Blindspots checklist) |
| `js/account-plan-presentation-ai.js` | Slide-deck fallback readers |
| `css/saos-strategic.css` | Styling for Blindspots checklist + linkage prompt |
| `tests/e2e/accounts.functional.spec.ts` | Updated autosave selector to `pursuit_thesis.thesis` |

## Validation

- `node --input-type=module --check` passes on every modified `.js` file.
- All in-place legacy fallbacks were exercised against the existing migration shape — older plans surface their original prose under the new merged fields, and the user can edit it down to the tighter form without re-authoring.
- No section ids were renamed, so downstream AI/PPTX presentation slot mapping (which keys off `sections.pursuit_thesis`, `sections.critical_unknowns`, etc.) continues to work without further changes.

## Sales-psychology rationale, in short

Each merge has a comment block in the source explaining why it was made. The unifying theme: every box on the canvas now answers a question that an executive actually responds to. Duplicate prose is eliminated, fishing prompts are removed, and the framework forces the rep to wire their selected tensions THROUGH the strategy they write.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6526189d-624a-49e5-8b3b-359e1bf192a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6526189d-624a-49e5-8b3b-359e1bf192a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

