### PR TITLE
Core vs Deep Dive view mode and export Smart Drop hardening

### DIFF
--- a/css/saos-strategic.css
+++ b/css/saos-strategic.css
@@ -852,6 +852,69 @@
     padding: 0.5rem 0.75rem 0.75rem;
 }
 
+/* Core vs. Deep Dive — TOC toggle (framework fatigue reducer) */
+.saos-view-mode {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.35rem 0.5rem;
+    flex-shrink: 0;
+    margin-bottom: 0.65rem;
+    padding: 0.45rem 0.55rem;
+    border-radius: 0.5rem;
+    border: 1px solid color-mix(in srgb, var(--border-color) 85%, transparent);
+    background: color-mix(in srgb, var(--bg-medium) 40%, transparent);
+}
+
+.saos-view-mode-label {
+    font-size: 0.6875rem;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    margin-right: 0.15rem;
+}
+
+.saos-view-mode-option {
+    appearance: none;
+    border: none;
+    background: transparent;
+    padding: 0.2rem 0.35rem;
+    font-size: 0.8125rem;
+    font-weight: 600;
+    color: var(--text-medium);
+    cursor: pointer;
+    border-radius: 0.35rem;
+    line-height: 1.2;
+    transition: color 150ms ease, background-color 150ms ease;
+}
+
+.saos-view-mode-option:hover,
+.saos-view-mode-option:focus-visible {
+    color: var(--text-light);
+    background: color-mix(in srgb, var(--bg-medium) 65%, transparent);
+    outline: none;
+}
+
+.saos-view-mode-option--active {
+    color: var(--primary-blue);
+    background: color-mix(in srgb, var(--primary-blue) 12%, transparent);
+}
+
+.saos-view-mode-sep {
+    color: var(--text-muted);
+    font-size: 0.75rem;
+    user-select: none;
+}
+
+/* Core view — hide Deep Dive-only framework sections on the canvas */
+#strategic-document-canvas.saos-mode-core #strategic-section-psychology,
+#strategic-document-canvas.saos-mode-core #strategic-section-strategic_tensions,
+#strategic-document-canvas.saos-mode-core #strategic-section-critical_unknowns,
+#strategic-document-canvas.saos-mode-core #strategic-section-entrenchment {
+    display: none !important;
+}
+
 .strategic-toc-body.hidden {
     display: none;
 }

--- a/js/account-plan-export-templates.js
+++ b/js/account-plan-export-templates.js
@@ -7,6 +7,7 @@ import {
     PSYCHOLOGY_SLIDERS,
     PLAN_306090_HORIZONS,
     TACTICAL_UX_LABELS,
+    ENTRY_POINT_FIELD_KEYS,
 } from './account-plan-sections.js';
 import { normalizePlan, INFLUENCE_CONTACT_FIELD_KEYS } from './account-plan-data.js';
 import { formatContactLabel, resolveContactById } from './account-plan-contacts.js';
@@ -19,6 +20,185 @@ import {
 } from './account-plan-export-brand.js';
 
 export const PLAN_SUMMARY_DOCUMENT_TITLE = 'Strategic Account Plan Summary';
+
+// ---------------------------------------------------------------------------
+// Smart Drop — export presence (null / whitespace / empty arrays)
+// ---------------------------------------------------------------------------
+
+/**
+ * @param {unknown} value
+ */
+export function hasMeaningfulText(value) {
+    if (value == null) return false;
+    if (Array.isArray(value)) {
+        return value.some((entry) => hasMeaningfulText(entry));
+    }
+    if (typeof value === 'object') {
+        return Object.values(value).some((entry) => hasMeaningfulText(entry));
+    }
+    return String(value).replace(/\s+/g, ' ').trim().length > 0;
+}
+
+/**
+ * @param {unknown} raw
+ * @returns {string[]}
+ */
+export function sanitizeStringArray(raw) {
+    if (!Array.isArray(raw)) return [];
+    return raw
+        .map((entry) => String(entry ?? '').trim())
+        .filter(Boolean);
+}
+
+/**
+ * @param {unknown} value
+ */
+function isPlanHorizonTextEmpty(value) {
+    const raw = String(value ?? '').trim();
+    if (!raw) return true;
+    const stripped = raw
+        .replace(/<[^>]+>/g, ' ')
+        .replace(/&nbsp;/gi, ' ')
+        .replace(/\s+/g, ' ')
+        .trim();
+    return stripped.length === 0;
+}
+
+/**
+ * True when a section has no rep-authored content — export engines should
+ * omit the entire block (no title, no empty-state placeholder).
+ *
+ * @param {import('./account-plan-sections.js').PlanSectionDef} section
+ * @param {Record<string, unknown>} sections
+ * @param {unknown[]} [contacts]
+ * @param {{ name?: string } | null} [account]
+ */
+export function isPlanSectionEmptyForExport(section, sections, contacts = [], account = null) {
+    const data = sections[section.id];
+
+    if (section.type === 'account_snapshot') {
+        const snap = isPlainObject(data) ? data : {};
+        const fields = section.fields || [];
+        const snapFilled = fields.some((field) => hasMeaningfulText(snap[field.key]));
+        const accountFilled = account && (
+            hasMeaningfulText(account.name)
+            || hasMeaningfulText(account.industry)
+            || account.employee_count != null
+            || account.quantity_of_sites != null
+            || hasMeaningfulText(account.address)
+        );
+        return !snapFilled && !accountFilled;
+    }
+
+    if (section.type === 'composite_textarea') {
+        const obj = isPlainObject(data) ? data : {};
+        return !(section.fields || []).some((field) => hasMeaningfulText(obj[field.key]));
+    }
+
+    if (section.type === 'triple_textarea') {
+        const obj = isPlainObject(data) ? data : {};
+        const horizons = section.horizons || PLAN_306090_HORIZONS;
+        const horizonFilled = horizons.some((field) => !isPlanHorizonTextEmpty(obj[field.key]));
+        const commitmentsFilled = sanitizeStringArray(obj.client_commitments).length > 0;
+        return !horizonFilled && !commitmentsFilled;
+    }
+
+    if (section.type === 'blindspots_list' || section.id === 'critical_unknowns') {
+        const obj = isPlainObject(sections.critical_unknowns) ? sections.critical_unknowns : {};
+        const items = sanitizeStringArray(obj.blindspots);
+        if (items.length > 0) return false;
+        const legacy = String(obj.unknowns ?? '')
+            .split(/\r?\n+/)
+            .map((line) => line.replace(/^[\s]*(?:[-*\u2022]\s+|\d+[.)]\s+)/, '').trim())
+            .filter(Boolean);
+        return legacy.length === 0;
+    }
+
+    if (section.type === 'pain_signals' || section.type === 'entrenchment') {
+        const obj = isPlainObject(data) ? data : {};
+        const pillField = section.pillField || 'selected_pills';
+        const pills = sanitizeStringArray(obj[pillField]);
+        const textFilled = (section.textFields || []).some(
+            (field) => hasMeaningfulText(obj[field.key])
+        );
+        if (section.type === 'entrenchment') {
+            return pills.length === 0 && !textFilled;
+        }
+        return pills.length === 0 && !textFilled;
+    }
+
+    if (section.type === 'pills_and_narrative') {
+        const obj = isPlainObject(data) ? data : {};
+        const pillField = section.pillField
+            || (Array.isArray(obj.positioning_pills) ? 'positioning_pills' : 'selected_pills');
+        const pills = sanitizeStringArray(obj[pillField]);
+        const textFilled = (section.textFields || []).some(
+            (field) => hasMeaningfulText(obj[field.key])
+        );
+        if (section.id === 'competitive_landscape') {
+            return pills.length === 0 && !textFilled;
+        }
+        return pills.length === 0 && !textFilled;
+    }
+
+    if (section.type === 'white_space_matrix') {
+        const rows = Array.isArray(sections.white_space) ? sections.white_space : [];
+        return !rows.some((row) => isPlainObject(row) && Object.values(row).some((v) => hasMeaningfulText(v)));
+    }
+
+    if (section.type === 'influence_board') {
+        const mapping = isPlainObject(data) ? data : {};
+        const hasContacts = ['executive', 'mid_level', 'technical'].some(
+            (key) => Array.isArray(mapping[key]) && mapping[key].length > 0
+        );
+        const accessPath = isPlainObject(mapping.access_path) ? mapping.access_path : {};
+        const hasText = [
+            mapping.invisible_org_chart,
+            mapping.political_dynamics,
+            accessPath.current,
+            accessPath.desired,
+            accessPath.bridge,
+            accessPath.strategy,
+        ].some((value) => hasMeaningfulText(value));
+        return !hasContacts && !hasText;
+    }
+
+    if (section.type === 'entry_point_carousel') {
+        const points = Array.isArray(sections.entry_points) ? sections.entry_points : [];
+        return !points.some((point) => {
+            if (!isPlainObject(point)) return false;
+            return ENTRY_POINT_FIELD_KEYS.some((key) => hasMeaningfulText(point[key]));
+        });
+    }
+
+    if (section.type === 'psychology_grid') {
+        const psych = isPlainObject(sections.psychology) ? sections.psychology : {};
+        const sliderMoved = PSYCHOLOGY_SLIDERS.some((slider) => {
+            const value = Number(psych[slider.id]);
+            return Number.isFinite(value) && Math.round(value) !== 3;
+        });
+        if (sliderMoved) return false;
+        const gravityFilled = (section.gravityFields || []).some(
+            (field) => hasMeaningfulText(psych[field.key])
+        );
+        if (gravityFilled) return false;
+        return !hasMeaningfulText(psych.narrative);
+    }
+
+    if (section.type === 'momentum') {
+        const momentum = isPlainObject(data) ? data : {};
+        const score = Number(momentum.score);
+        const scoreMoved = Number.isFinite(score) && Math.round(score) !== 3;
+        return !scoreMoved && !hasMeaningfulText(momentum.narrative);
+    }
+
+    if (section.type === 'timeline_view') {
+        const notes = getExportMomentumNotes(sections);
+        return notes.length === 0;
+    }
+
+    return !hasMeaningfulText(data);
+}
 
 /**
  * Short-form document label used in the per-page running header. Kept as a
@@ -721,6 +901,7 @@ export function buildDossierTemplate(plan, account) {
 
     const rawBlocks = PLAN_SECTIONS
         .filter((section) => section.exportDossier !== false)
+        .filter((section) => !isPlanSectionEmptyForExport(section, sections, contacts, account))
         // Thread `account` through — the account_snapshot section needs the
         // raw account record to render the "Firmographics (CRM)" panel
         // (name / industry / employee_count / sites / address / customer

--- a/js/account-plan-presentation-pptx.js
+++ b/js/account-plan-presentation-pptx.js
@@ -42,6 +42,7 @@ import {
 } from './account-plan-export-brand.js';
 import { normalizePlan } from './account-plan-data.js';
 import { TACTICAL_UX_LABELS } from './account-plan-sections.js';
+import { hasMeaningfulText, sanitizeStringArray } from './account-plan-export-templates.js';
 import { normalizePresentationHighlight } from './account-plan-presentation-ai.js';
 import { MOMENTUM_LABELS } from './account-plan-presentation-types.js';
 import { PSYCHOLOGY_SLIDERS } from './account-plan-sections.js';
@@ -251,9 +252,6 @@ export async function generateExecPresentationPptx(plan, account, presentationHi
     pptx.subject = `${accountName} — ${DOC_TITLE}`;
     pptx.title = `${accountName} — ${DOC_TITLE}`;
 
-    // Exec deck: exactly five content slides (no entry-point pagination).
-    const contentSlideCount = 5;
-
     // Define the master FIRST so every subsequent addSlide({ masterName })
     // call inherits it. We pass the per-deck running header text into
     // the master closure so the account name shows on every content slide
@@ -266,17 +264,28 @@ export async function generateExecPresentationPptx(plan, account, presentationHi
     buildCoverSlide(pptx, accountName, whiteLogo);
 
     // -----------------------------------------------------------------
-    // SLIDES 1–5 — content (all attach to MASTER_NAME)
+    // Content slides — Smart Drop omits empty psychology/tensions slide.
     // -----------------------------------------------------------------
+    /** @type {Array<(pageNum: number, totalSlides: number) => void>} */
+    const contentSlideBuilders = [
+        (pageNum, totalSlides) => buildExecutiveSummarySlide(pptx, highlight, ctx, pageNum, totalSlides),
+    ];
+    if (!isPsychologyTensionsSlideEmpty(ctx)) {
+        contentSlideBuilders.push(
+            (pageNum, totalSlides) => buildPsychologyTensionsSlide(pptx, ctx, pageNum, totalSlides)
+        );
+    }
+    contentSlideBuilders.push(
+        (pageNum, totalSlides) => buildBattlefieldSlide(pptx, highlight, ctx, pageNum, totalSlides),
+        (pageNum, totalSlides) => buildEntryPointsSlide(pptx, ctx, highlight, pageNum, totalSlides),
+        (pageNum, totalSlides) => buildExecutionRoadmapSlide(pptx, highlight, ctx, pageNum, totalSlides),
+    );
+
+    const contentSlideCount = contentSlideBuilders.length;
     let pageNum = 1;
-    buildExecutiveSummarySlide(pptx, highlight, ctx, pageNum++, contentSlideCount);
-    buildPsychologyTensionsSlide(pptx, ctx, pageNum++, contentSlideCount);
-    buildBattlefieldSlide(pptx, highlight, ctx, pageNum++, contentSlideCount);
-
-    // Slide 4 — ONE slide, TWO columns (entry_points[0] + [1]); never paginate for exec.
-    buildEntryPointsSlide(pptx, ctx, highlight, pageNum++, contentSlideCount);
-
-    buildExecutionRoadmapSlide(pptx, highlight, ctx, pageNum++, contentSlideCount);
+    contentSlideBuilders.forEach((buildSlide) => {
+        buildSlide(pageNum++, contentSlideCount);
+    });
 
     const arrayBuffer = await pptx.write({ outputType: 'arraybuffer' });
     return {
@@ -863,6 +872,45 @@ function resolvePursuitThesisProse(highlight, ctx) {
     return legacyParts.join('\n\n');
 }
 
+/**
+ * Psychology is "empty" when every slider is still at default (3) and no
+ * gravity narrative fields were authored.
+ *
+ * @param {ReturnType<typeof resolvePptxPlanContext>} ctx
+ */
+function isPsychologyDataEmpty(ctx) {
+    const psych = ctx.psychology;
+    const slidersDefault = PSYCHOLOGY_SLIDERS.every(
+        (slider) => clampScale(psych[slider.id], 3) === 3
+    );
+    if (!slidersDefault) return false;
+
+    const gravityFilled = [
+        'organizational_gravity',
+        'consensus_requirement',
+        'procurement_friction',
+        'innovation_friction',
+        'narrative',
+    ].some((key) => hasMeaningfulText(psych[key]));
+
+    return !gravityFilled;
+}
+
+/**
+ * @param {ReturnType<typeof resolvePptxPlanContext>} ctx
+ */
+function isStrategicTensionsDataEmpty(ctx) {
+    if (sanitizeStringArray(ctx.tensionPills).length > 0) return false;
+    return !hasMeaningfulText(ctx.tensionNarrative);
+}
+
+/**
+ * @param {ReturnType<typeof resolvePptxPlanContext>} ctx
+ */
+function isPsychologyTensionsSlideEmpty(ctx) {
+    return isPsychologyDataEmpty(ctx) && isStrategicTensionsDataEmpty(ctx);
+}
+
 // ---------------------------------------------------------------------------
 // Slide 2 — Psychology & Strategic Tensions
 // ---------------------------------------------------------------------------
@@ -1113,18 +1161,8 @@ function buildBattlefieldSlide(pptx, highlight, ctx, pageNum, totalSlides) {
     const slide = addContentSlide(pptx);
     addContentSlideChrome(slide, 'The Battlefield', pageNum, totalSlides);
 
-    const colW = (BODY_W - GAP) / 2;
-    const leftX = MARGIN_X;
-    const rightX = MARGIN_X + colW + GAP;
-
-    // LEFT — Competitive Landscape narrative.
-    addPanel(slide, leftX, BODY_TOP, colW, BODY_H);
-    const leftLayout = panelContentLayout(leftX, BODY_TOP, colW, BODY_H);
-    addKicker(slide, 'COMPETITIVE LANDSCAPE', leftLayout.innerX, leftLayout.kickerY, leftLayout.innerW);
-
-    const competitiveHeadline = String(highlight.slides.battlefield?.competitive?.headline ?? '').trim()
-        || 'Competitive Landscape';
-    addHeadline(slide, competitiveHeadline, leftLayout.innerX, leftLayout.headlineY, leftLayout.innerW, PANEL_HEADLINE_H);
+    const blindspotItems = resolveBattlefieldBlindspots(ctx, highlight);
+    const hasBlindspots = blindspotItems.length > 0;
 
     const aiBullets = Array.isArray(highlight.slides.battlefield?.competitive?.bullets)
         ? highlight.slides.battlefield.competitive.bullets
@@ -1138,35 +1176,62 @@ function buildBattlefieldSlide(pptx, highlight, ctx, pageNum, totalSlides) {
             String(ctx.competitive.narrative ?? '').trim(),
         ].filter(Boolean);
 
+    const competitiveHeadline = String(highlight.slides.battlefield?.competitive?.headline ?? '').trim()
+        || 'Competitive Landscape';
+
+    if (hasBlindspots) {
+        const colW = (BODY_W - GAP) / 2;
+        const leftX = MARGIN_X;
+        const rightX = MARGIN_X + colW + GAP;
+
+        addPanel(slide, leftX, BODY_TOP, colW, BODY_H);
+        const leftLayout = panelContentLayout(leftX, BODY_TOP, colW, BODY_H);
+        addKicker(slide, 'COMPETITIVE LANDSCAPE', leftLayout.innerX, leftLayout.kickerY, leftLayout.innerW);
+        addHeadline(slide, competitiveHeadline, leftLayout.innerX, leftLayout.headlineY, leftLayout.innerW, PANEL_HEADLINE_H);
+        addNativeBulletList(slide, competitiveBullets, {
+            x: leftLayout.innerX,
+            y: leftLayout.bodyY,
+            w: leftLayout.innerW,
+            h: leftLayout.bodyH,
+            fontSize: TYPO.body,
+            lineSpacing: 16,
+            color: THEME.primary,
+            bulletColor: THEME.accent,
+            emptyText: 'No competitive landscape captured yet.',
+        });
+
+        addPanel(slide, rightX, BODY_TOP, colW, BODY_H);
+        const rightLayout = panelContentLayout(rightX, BODY_TOP, colW, BODY_H);
+        addKicker(slide, 'THE BLINDSPOTS', rightLayout.innerX, rightLayout.kickerY, rightLayout.innerW);
+        addHeadline(slide, 'Questions we must answer next', rightLayout.innerX, rightLayout.headlineY, rightLayout.innerW, PANEL_HEADLINE_H);
+        addNativeBulletList(slide, blindspotItems, {
+            x: rightLayout.innerX,
+            y: rightLayout.bodyY,
+            w: rightLayout.innerW,
+            h: rightLayout.bodyH,
+            fontSize: TYPO.body,
+            lineSpacing: 16,
+            color: THEME.primary,
+            bullet: true,
+        });
+        return;
+    }
+
+    // No blindspots — expand competitive narrative to full slide width.
+    addPanel(slide, MARGIN_X, BODY_TOP, BODY_W, BODY_H);
+    const fullLayout = panelContentLayout(MARGIN_X, BODY_TOP, BODY_W, BODY_H);
+    addKicker(slide, 'COMPETITIVE LANDSCAPE', fullLayout.innerX, fullLayout.kickerY, fullLayout.innerW);
+    addHeadline(slide, competitiveHeadline, fullLayout.innerX, fullLayout.headlineY, fullLayout.innerW, PANEL_HEADLINE_H);
     addNativeBulletList(slide, competitiveBullets, {
-        x: leftLayout.innerX,
-        y: leftLayout.bodyY,
-        w: leftLayout.innerW,
-        h: leftLayout.bodyH,
+        x: '5%',
+        y: fullLayout.bodyY,
+        w: '90%',
+        h: fullLayout.bodyH,
         fontSize: TYPO.body,
         lineSpacing: 16,
         color: THEME.primary,
         bulletColor: THEME.accent,
         emptyText: 'No competitive landscape captured yet.',
-    });
-
-    // RIGHT — The Blindspots.
-    addPanel(slide, rightX, BODY_TOP, colW, BODY_H);
-    const rightLayout = panelContentLayout(rightX, BODY_TOP, colW, BODY_H);
-    addKicker(slide, 'THE BLINDSPOTS', rightLayout.innerX, rightLayout.kickerY, rightLayout.innerW);
-    addHeadline(slide, 'Questions we must answer next', rightLayout.innerX, rightLayout.headlineY, rightLayout.innerW, PANEL_HEADLINE_H);
-
-    const blindspotItems = resolveBattlefieldBlindspots(ctx, highlight);
-    addNativeBulletList(slide, blindspotItems, {
-        x: rightLayout.innerX,
-        y: rightLayout.bodyY,
-        w: rightLayout.innerW,
-        h: rightLayout.bodyH,
-        fontSize: TYPO.body,
-        lineSpacing: 16,
-        color: THEME.primary,
-        bullet: true,
-        fallbackItems: ['No blindspots documented.'],
     });
 }
 

--- a/js/account-plan-sections.js
+++ b/js/account-plan-sections.js
@@ -8,6 +8,14 @@
  * Tactical, locker-room labels for canvas + exports. Data keys stay stable
  * (e.g. `pursuit_thesis`) — only user-facing copy changes.
  */
+/** Section ids hidden in Core view mode (Deep Dive shows all). */
+export const SAOS_CORE_HIDDEN_SECTION_IDS = Object.freeze([
+    'psychology',
+    'strategic_tensions',
+    'critical_unknowns',
+    'entrenchment',
+]);
+
 export const TACTICAL_UX_LABELS = Object.freeze({
     pursuitThesis: 'The Big Play',
     actionForcingEvent: 'Action-Forcing Event (Why Now?)',

--- a/js/account-plan-ui.js
+++ b/js/account-plan-ui.js
@@ -26,6 +26,7 @@ import {
     INSIGHT_DENSITY_SECTIONS,
     INSIGHT_DENSITY_SOFT_LIMIT,
     TACTICAL_UX_LABELS,
+    SAOS_CORE_HIDDEN_SECTION_IDS,
 } from './account-plan-sections.js';
 import { formatPlanHorizonRailPreviewHtml } from './account-plan-rich-text.js';
 import {
@@ -259,6 +260,7 @@ function updateAccountPickerForMode(mode) {
     }
 
     if (isStrategic) {
+        loadSaosViewMode();
         renderStrategicToc();
         initStrategicTocClicks();
     }
@@ -271,16 +273,84 @@ function updateAccountPickerForMode(mode) {
  * Click handling lives in a delegated listener (initStrategicTocClicks below)
  * so re-rendering the nav doesn't drop any handlers.
  */
+/**
+ * @returns {import('./account-plan-sections.js').PlanSectionDef[]}
+ */
+function getCanvasPlanSections() {
+    if (_saosViewMode === 'core') {
+        return PLAN_SECTIONS.filter((section) => !SAOS_CORE_HIDDEN_SECTION_IDS.includes(section.id));
+    }
+    return PLAN_SECTIONS;
+}
+
+function loadSaosViewMode() {
+    try {
+        const stored = localStorage.getItem(SAOS_VIEW_MODE_STORAGE_KEY);
+        _saosViewMode = stored === 'deep' ? 'deep' : 'core';
+    } catch {
+        _saosViewMode = 'core';
+    }
+}
+
+/**
+ * @param {SaosViewMode} mode
+ */
+function setSaosViewMode(mode) {
+    _saosViewMode = mode === 'deep' ? 'deep' : 'core';
+    try {
+        localStorage.setItem(SAOS_VIEW_MODE_STORAGE_KEY, _saosViewMode);
+    } catch {
+        /* ignore quota / private mode */
+    }
+    applySaosViewModeToCanvas();
+    renderStrategicToc();
+    paintCanvas();
+}
+
+function applySaosViewModeToCanvas() {
+    const canvas = document.getElementById('strategic-document-canvas');
+    if (!(canvas instanceof HTMLElement)) return;
+    canvas.classList.toggle('saos-mode-core', _saosViewMode === 'core');
+    canvas.classList.toggle('saos-mode-deep', _saosViewMode === 'deep');
+}
+
+function renderStrategicViewModeToggleHtml() {
+    const isCore = _saosViewMode === 'core';
+    return `
+        <div class="saos-view-mode" role="group" aria-label="Plan view mode">
+            <span class="saos-view-mode-label">View Mode:</span>
+            <button
+                type="button"
+                class="saos-view-mode-option${isCore ? ' saos-view-mode-option--active' : ''}"
+                data-view-mode="core"
+                aria-pressed="${isCore ? 'true' : 'false'}"
+            >Core</button>
+            <span class="saos-view-mode-sep" aria-hidden="true">|</span>
+            <button
+                type="button"
+                class="saos-view-mode-option${!isCore ? ' saos-view-mode-option--active' : ''}"
+                data-view-mode="deep"
+                aria-pressed="${!isCore ? 'true' : 'false'}"
+            >Deep Dive</button>
+        </div>`;
+}
+
 function renderStrategicToc() {
-    const nav = document.getElementById('strategic-toc-nav');
-    if (!nav) return;
-    nav.innerHTML = PLAN_SECTIONS.map((section) => (
-        `<a href="#strategic-section-${section.id}"`
-        + ` class="strategic-toc-link"`
-        + ` data-section-id="${section.id}">`
-        + escapeHtml(section.title)
-        + `</a>`
-    )).join('');
+    const tocBody = document.getElementById('strategic-toc-body');
+    if (!tocBody) return;
+
+    const sections = getCanvasPlanSections();
+    tocBody.innerHTML = `
+        ${renderStrategicViewModeToggleHtml()}
+        <nav id="strategic-toc-nav" class="strategic-toc-nav" aria-label="Plan table of contents">
+            ${sections.map((section) => (
+                `<a href="#strategic-section-${section.id}"`
+                + ` class="strategic-toc-link"`
+                + ` data-section-id="${section.id}">`
+                + escapeHtml(section.title)
+                + `</a>`
+            )).join('')}
+        </nav>`;
 }
 
 let _strategicTocClicksBound = false;
@@ -296,14 +366,25 @@ let _strategicTocClicksBound = false;
  */
 function initStrategicTocClicks() {
     if (_strategicTocClicksBound) return;
-    const nav = document.getElementById('strategic-toc-nav');
-    if (!nav) return;
+    const tocBody = document.getElementById('strategic-toc-body');
+    if (!tocBody) return;
     _strategicTocClicksBound = true;
 
-    nav.addEventListener('click', (event) => {
-        const link = event.target instanceof Element
-            ? event.target.closest('.strategic-toc-link')
-            : null;
+    tocBody.addEventListener('click', (event) => {
+        const target = event.target;
+        if (!(target instanceof Element)) return;
+
+        const modeBtn = target.closest('[data-view-mode]');
+        if (modeBtn instanceof HTMLButtonElement) {
+            event.preventDefault();
+            const mode = modeBtn.dataset.viewMode === 'deep' ? 'deep' : 'core';
+            if (mode !== _saosViewMode) {
+                setSaosViewMode(mode);
+            }
+            return;
+        }
+
+        const link = target.closest('.strategic-toc-link');
         if (!(link instanceof HTMLAnchorElement)) return;
         event.preventDefault();
 
@@ -313,7 +394,7 @@ function initStrategicTocClicks() {
         if (!sectionEl) return;
 
         sectionEl.scrollIntoView({ behavior: 'smooth', block: 'start' });
-        nav.querySelectorAll('.strategic-toc-link').forEach((el) => el.classList.remove('active'));
+        tocBody.querySelectorAll('.strategic-toc-link').forEach((el) => el.classList.remove('active'));
         link.classList.add('active');
     });
 }
@@ -441,6 +522,8 @@ export function renderStrategicShell(account, plan) {
     }
 
     if (canvas) {
+        loadSaosViewMode();
+        applySaosViewModeToCanvas();
         paintCanvas();
         bindCanvasFormEvents(canvas);
     }
@@ -3002,7 +3085,7 @@ export function promoteActivityToInteractionLog(activity) {
  * @param {number} [entryPointActiveIndex]
  */
 function buildCanvasHtml(sections, entryPointActiveIndex = 0) {
-    return PLAN_SECTIONS.map((section) => {
+    return getCanvasPlanSections().map((section) => {
         const headingId = `strategic-heading-${section.id}`;
         const sectionId = `strategic-section-${section.id}`;
         const headerContext = buildSectionHeaderContext(section);
@@ -3348,10 +3431,11 @@ function isSectionFilled(section, sections) {
  * @param {Record<string, unknown>} sections
  */
 function computePlanCompleteness(sections) {
-    const total = PLAN_SECTIONS.length;
+    const visibleSections = getCanvasPlanSections();
+    const total = visibleSections.length;
     if (total === 0) return { filled: 0, total: 0, percent: 0 };
 
-    const filled = PLAN_SECTIONS.filter((section) => isSectionFilled(section, sections)).length;
+    const filled = visibleSections.filter((section) => isSectionFilled(section, sections)).length;
     const percent = Math.round((filled / total) * 100);
     return { filled, total, percent };
 }
@@ -3652,6 +3736,13 @@ function updateRailSummaries(sections) {
 }
 
 let _draggedInfluenceContactId = null;
+
+/** @typedef {'core' | 'deep'} SaosViewMode */
+
+const SAOS_VIEW_MODE_STORAGE_KEY = 'saos-view-mode';
+
+/** @type {SaosViewMode} */
+let _saosViewMode = 'core';
 
 /**
  * Push a new blindspot string into the live plan, persist, and re-render


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reduces framework fatigue for reps with a **Core vs Deep Dive** canvas toggle, and hardens PDF/PPTX exports so empty sections never render as orphaned headers or blank panels.

## Task 1 — UI toggle (Core vs Deep Dive)

- TOC rail toggle: **View Mode: Core | Deep Dive** (default **Core**), persisted in `localStorage` (`saos-view-mode`).
- Applies `.saos-mode-core` on `#strategic-document-canvas` when Core is active.
- CSS hides Deep Dive-only sections: How They Buy, Competing Priorities, The Blindspots, The Incumbent's Grip.
- Plan completeness scoring uses only sections visible in the active view mode.

## Task 2 — PDF dossier Smart Drop

- `hasMeaningfulText`, `sanitizeStringArray`, and `isPlanSectionEmptyForExport` guard all dossier section blocks.
- Empty/null/whitespace-only data and empty arrays skip the entire HTML wrapper (no placeholder shells).
- `buildDossierTemplate` filters sections before `buildDossierSectionUnits` so pagination reclaims vertical space.

## Task 3 — PPTX dynamic geometry

- Psychology + Strategic Tensions slide omitted when both blocks are default/empty.
- Battlefield: when `blindspots` is empty, right column is dropped and competitive landscape expands to `w: '90%'` at `x: '5%'`.

## Files changed

- `js/account-plan-ui.js`
- `css/saos-strategic.css`
- `js/account-plan-sections.js` (`SAOS_CORE_HIDDEN_SECTION_IDS`)
- `js/account-plan-export-templates.js`
- `js/account-plan-presentation-pptx.js`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9e31a0ad-59fc-4bb0-a425-2601630805f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9e31a0ad-59fc-4bb0-a425-2601630805f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

