### PR TITLE
Restore nested entry-point pills and integrate Give/Get column

### DIFF
--- a/css/saos-strategic.css
+++ b/css/saos-strategic.css
@@ -289,6 +289,186 @@
     color: var(--text-muted);
 }
 
+/* 30/60/90 + Give/Get — four peer columns (matches summary export grid). */
+.plan-306090-board {
+    border: 1px solid var(--border-color);
+    border-radius: 0.5rem;
+    background-color: color-mix(in srgb, var(--bg-medium) 40%, transparent);
+    padding: 0.75rem;
+}
+
+.plan-306090-columns {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 0.75rem;
+    align-items: stretch;
+}
+
+.plan-306090-column {
+    display: flex;
+    flex-direction: column;
+    gap: 0.625rem;
+    min-width: 0;
+    padding: 0.625rem 0.75rem;
+    border-radius: 0.375rem;
+    border: 1px solid color-mix(in srgb, var(--border-color) 80%, transparent);
+    background: color-mix(in srgb, var(--bg-light) 92%, transparent);
+}
+
+.plan-306090-column:not(:last-child) {
+    border-right: 1px solid color-mix(in srgb, var(--border-color) 70%, transparent);
+}
+
+.plan-306090-column-head {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.625rem;
+    min-width: 0;
+}
+
+.plan-306090-badge--give-get {
+    font-size: 0.8125rem;
+    letter-spacing: -0.02em;
+}
+
+.plan-306090-column--give-get .plan-306090-textarea {
+    display: none;
+}
+
+.client-commitment-chips {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.375rem;
+    flex: 1 1 auto;
+    min-height: 0;
+}
+
+.client-commitment-chip {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.375rem;
+    padding: 0.375rem 0.5rem;
+    border-radius: 0.375rem;
+    border: 1px solid color-mix(in srgb, var(--primary-blue) 28%, var(--border-color));
+    background: color-mix(in srgb, var(--primary-blue) 8%, var(--bg-medium));
+    font-size: 0.8125rem;
+    line-height: 1.4;
+    color: var(--text-light);
+}
+
+.client-commitment-chip--empty {
+    border-style: dashed;
+    color: var(--text-muted);
+    font-style: italic;
+    background: transparent;
+}
+
+.client-commitment-chip__text {
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
+.client-commitment-chip__remove {
+    flex-shrink: 0;
+    appearance: none;
+    border: none;
+    background: transparent;
+    color: var(--text-muted);
+    font-size: 1rem;
+    line-height: 1;
+    cursor: pointer;
+    padding: 0 0.125rem;
+}
+
+.client-commitment-chip__remove:hover {
+    color: var(--text-light);
+}
+
+.client-commitment-add-row {
+    display: flex;
+    gap: 0.375rem;
+    margin-top: 0.25rem;
+}
+
+.client-commitment-add-input {
+    flex: 1 1 auto;
+    min-width: 0;
+    border-radius: 0.375rem;
+    border: 1px solid var(--border-color);
+    padding: 0.375rem 0.5rem;
+    font-size: 0.8125rem;
+    background: var(--bg-light);
+    color: var(--text-light);
+}
+
+.client-commitment-add-btn {
+    flex-shrink: 0;
+    border-radius: 0.375rem;
+    border: 1px solid var(--primary-blue);
+    background: color-mix(in srgb, var(--primary-blue) 12%, transparent);
+    color: var(--primary-blue);
+    font-size: 0.75rem;
+    font-weight: 600;
+    padding: 0.375rem 0.625rem;
+    cursor: pointer;
+}
+
+.client-commitment-add-btn:hover {
+    background: color-mix(in srgb, var(--primary-blue) 20%, transparent);
+}
+
+@media (max-width: 1100px) {
+    .plan-306090-columns {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+}
+
+@media (max-width: 640px) {
+    .plan-306090-columns {
+        grid-template-columns: 1fr;
+    }
+}
+
+/* Entry Point relationship profile — label nested inside attribute chip. */
+.entry-point-grid--attributes {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.entry-point-attribute-chip {
+    flex: 1 1 7.5rem;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    padding: 0.45rem 0.55rem 0.5rem;
+    border-radius: 0.5rem;
+    border: 1px solid var(--border-color);
+    background: color-mix(in srgb, var(--bg-medium) 55%, transparent);
+}
+
+.entry-point-attribute-chip__label {
+    font-size: 0.625rem;
+    font-weight: 700;
+    letter-spacing: 0.07em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    line-height: 1.2;
+}
+
+.entry-point-attribute-chip .entry-point-pills-wrap {
+    gap: 0.25rem;
+}
+
+.entry-point-attribute-chip .entry-point-pill {
+    padding: 0.15rem 0.45rem;
+    font-size: 0.6875rem;
+}
+
 /* Entry Point carousel tabs — pill-shaped, bordered, with a clear active state.
  * Same trailing-declaration issue: color/cursor on the base tab and color on
  * the active tab were being dropped after the @supports background-color block. */

--- a/js/account-plan-export-templates.js
+++ b/js/account-plan-export-templates.js
@@ -651,24 +651,12 @@ export function buildSlide3Execution(plan, account, pageInfo = { pageNumber: 3, 
             planGrid.appendChild(col);
         });
     }
-    planPanel.appendChild(planGrid);
-
     const commitments = Array.isArray(ctx.plan306090?.client_commitments)
         ? ctx.plan306090.client_commitments
         : [];
-    if (commitments.length > 0) {
-        const giveGet = document.createElement('div');
-        giveGet.className = 'ap-exec-client-commitments';
-        giveGet.innerHTML = `<h4 class="ap-exec-plan-horizon-title">${escapeHtml(TACTICAL_UX_LABELS.clientCommitments)}</h4>`;
-        const list = document.createElement('ul');
-        list.className = 'ap-exec-highlight-list ap-exec-highlight-list--compact';
-        list.innerHTML = commitments
-            .map((entry) => `<li>${escapeHtml(String(entry ?? '').trim())}</li>`)
-            .filter(Boolean)
-            .join('');
-        giveGet.appendChild(list);
-        planPanel.appendChild(giveGet);
-    }
+    planGrid.classList.add('ap-exec-plan-horizons--with-give-get');
+    planGrid.appendChild(createExecGiveGetColumn(commitments));
+    planPanel.appendChild(planGrid);
 
     const signalsPanel = createExecPanel('ap-exec-panel--signals', 'Strategic Signals', 'momentum_timeline');
     const signalsList = document.createElement('ul');
@@ -996,11 +984,104 @@ function createProfileField(kicker, text) {
  * @param {string} label
  * @param {unknown} value
  */
-function createStatusBadge(label, value) {
-    const badge = document.createElement('span');
-    badge.className = 'ap-export-badge';
-    badge.textContent = `${label}: ${String(value).trim()}`;
-    return badge;
+/**
+ * Relationship-profile chip: label nested above the selected value.
+ *
+ * @param {string} label
+ * @param {unknown} value
+ */
+function createAttributePill(label, value) {
+    const pill = document.createElement('span');
+    pill.className = 'ap-export-attribute-pill';
+
+    const labelEl = document.createElement('span');
+    labelEl.className = 'ap-export-attribute-pill__label';
+    labelEl.textContent = label;
+
+    const valueEl = document.createElement('span');
+    valueEl.className = 'ap-export-attribute-pill__value';
+    valueEl.textContent = String(value ?? '').trim() || '—';
+
+    pill.appendChild(labelEl);
+    pill.appendChild(valueEl);
+    return pill;
+}
+
+/**
+ * @param {string[]} commitments
+ */
+function createEditorialGiveGetCell(commitments) {
+    const cell = document.createElement('div');
+    cell.className = 'ap-export-editorial-cell ap-export-editorial-cell--give-get';
+
+    const label = document.createElement('h3');
+    label.className = 'ap-export-editorial-kicker';
+    label.textContent = TACTICAL_UX_LABELS.giveGetColumn;
+    cell.appendChild(label);
+
+    const pills = document.createElement('div');
+    pills.className = 'ap-export-commitment-pills';
+
+    const items = commitments
+        .map((entry) => String(entry ?? '').trim())
+        .filter(Boolean);
+
+    if (items.length === 0) {
+        const empty = document.createElement('p');
+        empty.className = 'ap-export-editorial-empty ap-export-commitment-pills-empty';
+        empty.textContent = 'What does the customer owe us this month to keep the deal moving?';
+        pills.appendChild(empty);
+    } else {
+        items.forEach((text) => {
+            const pill = document.createElement('span');
+            pill.className = 'ap-export-commitment-pill';
+            pill.textContent = text;
+            pills.appendChild(pill);
+        });
+    }
+
+    cell.appendChild(pills);
+    return cell;
+}
+
+/**
+ * @param {string[]} commitments
+ */
+function createExecGiveGetColumn(commitments) {
+    const col = document.createElement('div');
+    col.className = 'ap-exec-plan-horizon-col ap-exec-plan-horizon-col--give-get';
+
+    const title = document.createElement('h3');
+    title.className = 'ap-exec-plan-horizon-title';
+    title.textContent = TACTICAL_UX_LABELS.giveGetColumn;
+    col.appendChild(title);
+
+    const body = document.createElement('div');
+    body.className = 'ap-exec-plan-horizon-body ap-exec-plan-horizon-body--give-get';
+
+    const items = commitments
+        .map((entry) => String(entry ?? '').trim())
+        .filter(Boolean);
+
+    if (items.length === 0) {
+        const empty = document.createElement('p');
+        empty.className = 'ap-exec-plan-give-get-empty';
+        empty.textContent = 'What does the customer owe us this month to keep the deal moving?';
+        body.appendChild(empty);
+    } else {
+        const pills = document.createElement('div');
+        pills.className = 'ap-export-commitment-pills';
+        items.forEach((text) => {
+            const pill = document.createElement('span');
+            pill.className = 'ap-export-commitment-pill';
+            pill.textContent = text;
+            pills.appendChild(pill);
+        });
+        body.appendChild(pills);
+    }
+
+    col.appendChild(body);
+    return col;
 }
 
 /**
@@ -1038,7 +1119,7 @@ function buildTargetProfile(rawPoint) {
         const badgeRow = document.createElement('div');
         badgeRow.className = 'ap-export-badge-row';
         badgeDefs.forEach(([label, val]) => {
-            badgeRow.appendChild(createStatusBadge(label, val));
+            badgeRow.appendChild(createAttributePill(label, val));
         });
         header.appendChild(badgeRow);
     }
@@ -1749,38 +1830,16 @@ function buildDossierSectionUnits(section, sections, contacts = [], account = nu
         const stack = document.createElement('div');
         stack.className = 'ap-export-plan306090-stack';
 
-        const grid = createEditorialGrid('ap-export-editorial-grid--3 ap-export-editorial-grid--plan');
+        const commitments = Array.isArray(plan306090.client_commitments) ? plan306090.client_commitments : [];
+        const grid = createEditorialGrid('ap-export-editorial-grid--4 ap-export-editorial-grid--plan');
         PLAN_306090_HORIZONS.forEach((horizon) => {
             grid.appendChild(createEditorialPlanHorizonCell(
                 horizon.title,
                 plan306090[horizon.key]
             ));
         });
+        grid.appendChild(createEditorialGiveGetCell(commitments));
         stack.appendChild(grid);
-
-        const commitments = Array.isArray(plan306090.client_commitments) ? plan306090.client_commitments : [];
-        const giveGet = document.createElement('div');
-        giveGet.className = 'ap-export-client-commitments';
-        giveGet.innerHTML = `<h3 class="ap-export-editorial-kicker">${escapeHtml(TACTICAL_UX_LABELS.clientCommitments)}</h3>`;
-        if (commitments.length === 0) {
-            const empty = document.createElement('p');
-            empty.className = 'ap-export-editorial-empty';
-            empty.textContent = 'What does the customer owe us this month to keep the deal moving?';
-            giveGet.appendChild(empty);
-        } else {
-            const list = document.createElement('ul');
-            list.className = 'ap-export-blindspots-list';
-            commitments.forEach((entry) => {
-                const text = String(entry ?? '').trim();
-                if (!text) return;
-                const li = document.createElement('li');
-                li.className = 'ap-export-blindspots-item';
-                li.textContent = text;
-                list.appendChild(li);
-            });
-            giveGet.appendChild(list);
-        }
-        stack.appendChild(giveGet);
 
         return [createDossierSectionBlock(section, stack)];
     }
@@ -2657,9 +2716,12 @@ export function ensureExportTemplateStyles() {
         .ap-export-editorial-grid--2 {
             grid-template-columns: repeat(2, minmax(0, 1fr));
         }
-        .ap-export-editorial-grid--3,
-        .ap-export-editorial-grid--plan {
+        .ap-export-editorial-grid--3 {
             grid-template-columns: repeat(3, minmax(0, 1fr));
+        }
+        .ap-export-editorial-grid--4,
+        .ap-export-editorial-grid--plan {
+            grid-template-columns: repeat(4, minmax(0, 1fr));
         }
         .ap-export-editorial-cell {
             padding: 0 18px 0 0;
@@ -2670,8 +2732,33 @@ export function ensureExportTemplateStyles() {
             margin-right: 0;
         }
         .ap-export-editorial-grid--3 > .ap-export-editorial-cell,
+        .ap-export-editorial-grid--4 > .ap-export-editorial-cell,
         .ap-export-editorial-grid--plan > .ap-export-editorial-cell {
             padding: 0 18px;
+        }
+        .ap-export-editorial-cell--give-get .ap-export-commitment-pills {
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+            margin-top: 4px;
+        }
+        .ap-export-commitment-pill {
+            display: block;
+            padding: 6px 9px;
+            border-radius: 4px;
+            border: 1px solid #cbd5e1;
+            background: #f8fafc;
+            font-size: 10.5px;
+            line-height: 1.45;
+            color: #0f172a;
+            font-weight: 500;
+        }
+        .ap-export-commitment-pills-empty {
+            margin: 4px 0 0;
+            font-size: 10.5px;
+            line-height: 1.45;
+            color: #94a3b8;
+            font-style: italic;
         }
         .ap-export-editorial-span-full {
             grid-column: 1 / -1;
@@ -2947,21 +3034,33 @@ export function ensureExportTemplateStyles() {
         .ap-export-badge-row {
             display: flex;
             flex-wrap: wrap;
-            gap: 4px;
+            gap: 5px;
         }
-        .ap-export-badge {
-            display: inline-block;
-            font-size: 8.5px;
-            text-transform: uppercase;
-            background: #f1f5f9;
+        .ap-export-attribute-pill {
+            display: inline-flex;
+            flex-direction: column;
+            align-items: flex-start;
+            gap: 1px;
+            min-width: 4.25rem;
+            padding: 3px 7px 4px;
+            border-radius: 4px;
             border: 1px solid #cbd5e1;
-            padding: 2px 5px;
-            border-radius: 3px;
-            margin-right: 0;
-            color: #475569;
-            font-weight: 600;
-            letter-spacing: 0.03em;
-            line-height: 1.2;
+            background: #f8fafc;
+            line-height: 1.15;
+        }
+        .ap-export-attribute-pill__label {
+            font-size: 7px;
+            font-weight: 700;
+            letter-spacing: 0.07em;
+            text-transform: uppercase;
+            color: #64748b;
+        }
+        .ap-export-attribute-pill__value {
+            font-size: 9px;
+            font-weight: 700;
+            letter-spacing: 0.04em;
+            text-transform: uppercase;
+            color: #0f172a;
         }
         .ap-export-target-profile-grid {
             display: grid;
@@ -3573,11 +3672,35 @@ export function ensureExportTemplateStyles() {
             font-size: 13px;
             color: #0f172a;
         }
-        .ap-exec-slide .ap-export-badge {
+        .ap-exec-slide .ap-export-attribute-pill {
             background: #eff6ff;
-            color: #1e40af;
             border: 1px solid #bfdbfe;
-            font-size: 9px;
+        }
+        .ap-exec-slide .ap-export-attribute-pill__label {
+            color: #64748b;
+        }
+        .ap-exec-slide .ap-export-attribute-pill__value {
+            color: #1e40af;
+        }
+        .ap-exec-plan-horizons--with-give-get {
+            grid-template-columns: repeat(4, minmax(0, 1fr));
+        }
+        .ap-exec-plan-horizon-col--give-get {
+            border-left: 1px solid #334155;
+            padding-left: 12px;
+        }
+        .ap-exec-plan-give-get-empty {
+            margin: 0;
+            font-size: 11px;
+            line-height: 1.45;
+            color: #64748b;
+            font-style: italic;
+        }
+        .ap-exec-slide .ap-export-commitment-pill {
+            background: #1e293b;
+            border-color: #334155;
+            color: #e2e8f0;
+            font-size: 10px;
         }
         .ap-exec-slide .ap-export-target-profile-group-title {
             color: #64748b;

--- a/js/account-plan-presentation-pptx.js
+++ b/js/account-plan-presentation-pptx.js
@@ -1370,31 +1370,38 @@ function buildExecutionRoadmapSlide(pptx, highlight, ctx, pageNum, totalSlides) 
     ];
     const cellRows = horizons.map((h) => composePlanCellLines(h.block, h.fallback));
 
-    const commitments = ctx.plan306090.client_commitments;
-    const hasCommitments = commitments.length > 0;
+    const commitments = ctx.plan306090.client_commitments
+        .map((entry) => String(entry ?? '').trim())
+        .filter(Boolean);
+    const giveGetLines = commitments.length > 0
+        ? commitments
+        : ['What does the customer owe us this month to keep the deal moving?'];
+
     const tableX = MARGIN_X + 0.25;
     const tableY = topY + 0.65;
     const tableW = BODY_W - 0.50;
-    const tableH = hasCommitments ? topH - 1.55 : topH - 0.85;
-    const colW = tableW / 3;
+    const tableH = topH - 0.85;
+    const colCount = 4;
+    const colW = tableW / colCount;
 
-    // Header row — uppercase period labels with accent fill (brand teal).
-    const headerRow = horizons.map((h) => ({
-        text: h.period,
-        options: {
-            bold: true,
-            color: 'FFFFFF',
-            fill: { color: THEME.accent },
-            align: 'center',
-            valign: 'middle',
-            fontSize: 11,
-            fontFace: THEME.font,
-            charSpacing: 1.5,
-        },
-    }));
+    const headerCellOptions = {
+        bold: true,
+        color: 'FFFFFF',
+        fill: { color: THEME.accent },
+        align: 'center',
+        valign: 'middle',
+        fontSize: 11,
+        fontFace: THEME.font,
+        charSpacing: 1.5,
+    };
 
-    // Body row — each cell holds a small bulleted prose block.
-    const bodyRow = cellRows.map((lines) => ({
+    // Header row — 30/60/90 + Give/Get as peer columns.
+    const headerRow = [
+        ...horizons.map((h) => ({ text: h.period, options: headerCellOptions })),
+        { text: TACTICAL_UX_LABELS.giveGetColumn.toUpperCase(), options: headerCellOptions },
+    ];
+
+    const buildBulletedCell = (lines, emptyText) => ({
         text: lines.length > 0
             ? lines.map((line, idx) => ({
                 text: line,
@@ -1407,7 +1414,7 @@ function buildExecutionRoadmapSlide(pptx, highlight, ctx, pageNum, totalSlides) 
                 },
             }))
             : [{
-                text: 'No actions captured yet.',
+                text: emptyText,
                 options: { italic: true, color: THEME.softMuted, fontFace: THEME.font, fontSize: 10 },
             }],
         options: {
@@ -1415,48 +1422,27 @@ function buildExecutionRoadmapSlide(pptx, highlight, ctx, pageNum, totalSlides) 
             valign: 'top',
             margin: 6,
         },
-    }));
+    });
+
+    const bodyRow = [
+        ...cellRows.map((lines) => buildBulletedCell(lines, 'No actions captured yet.')),
+        buildBulletedCell(
+            giveGetLines,
+            'What does the customer owe us this month to keep the deal moving?'
+        ),
+    ];
 
     slide.addTable([headerRow, bodyRow], {
         x: tableX,
         y: tableY,
         w: tableW,
         h: tableH,
-        colW: [colW, colW, colW],
+        colW: Array(colCount).fill(colW),
         rowH: [0.40, tableH - 0.40],
         border: { type: 'solid', color: THEME.panelBorder, pt: 0.75 },
         fontFace: THEME.font,
         autoPage: false,
     });
-
-    if (hasCommitments) {
-        const giveGetY = tableY + tableH + 0.12;
-        slide.addText(TACTICAL_UX_LABELS.clientCommitments.toUpperCase(), {
-            x: MARGIN_X + 0.30,
-            y: giveGetY,
-            w: BODY_W - 0.60,
-            h: 0.22,
-            fontSize: TYPO.kicker,
-            bold: true,
-            color: THEME.accent,
-            fontFace: THEME.font,
-            valign: 'top',
-            breakLine: true,
-            margin: 0,
-            autoFit: false,
-        });
-        addNativeBulletList(slide, commitments, {
-            x: MARGIN_X + 0.30,
-            y: giveGetY + 0.26,
-            w: BODY_W - 0.60,
-            h: topY + topH - (giveGetY + 0.26) - 0.12,
-            fontSize: TYPO.body,
-            lineSpacing: 16,
-            color: THEME.primary,
-            bullet: true,
-            fallbackItems: ['No client commitments documented.'],
-        });
-    }
 
     // BOTTOM — Strategic Signals.
     addPanel(slide, MARGIN_X, bottomY, BODY_W, bottomH);

--- a/js/account-plan-sections.js
+++ b/js/account-plan-sections.js
@@ -16,6 +16,16 @@ export const TACTICAL_UX_LABELS = Object.freeze({
     humanContext: 'The Off-the-Record Read',
     incumbentGrip: "The Incumbent's Grip",
     clientCommitments: 'Client Commitments (The Give/Get)',
+    giveGetColumn: 'Give / Get',
+});
+
+/** Short labels for relationship-profile attribute chips (canvas + export). */
+export const ENTRY_POINT_ATTRIBUTE_SHORT_LABELS = Object.freeze({
+    trust_level: 'Trust',
+    responsiveness: 'Response',
+    political_influence: 'Influence',
+    comm_style: 'Comm',
+    compound_potential: 'Compound',
 });
 
 /** @typedef {'none' | 'lead' | 'block'} SectionContextMode */

--- a/js/account-plan-ui.js
+++ b/js/account-plan-ui.js
@@ -26,6 +26,7 @@ import {
     INSIGHT_DENSITY_SECTIONS,
     INSIGHT_DENSITY_SOFT_LIMIT,
     TACTICAL_UX_LABELS,
+    ENTRY_POINT_ATTRIBUTE_SHORT_LABELS,
 } from './account-plan-sections.js';
 import { formatPlanHorizonRailPreviewHtml } from './account-plan-rich-text.js';
 import {
@@ -1301,12 +1302,12 @@ function buildPlan306090Html(section, data) {
     const planData = isPlainObject(data) ? data : {};
     const horizons = section.horizons || PLAN_306090_HORIZONS;
 
-    const horizonsHtml = `<div class="plan-306090-grid">${horizons.map((horizon) => {
+    const horizonColumns = horizons.map((horizon) => {
         const value = escapeHtml(String(planData[horizon.key] ?? ''));
         const fieldId = `plan-${horizon.key}`;
         return `
-            <div class="plan-306090-row">
-                <div class="plan-306090-row-meta">
+            <div class="plan-306090-column">
+                <div class="plan-306090-column-head">
                     <span class="plan-306090-badge" aria-hidden="true">${escapeHtml(horizon.badge)}</span>
                     <div class="plan-306090-column-heading">
                         <h5 class="plan-306090-column-title">${escapeHtml(horizon.title)}</h5>
@@ -1317,58 +1318,68 @@ function buildPlan306090Html(section, data) {
                     id="${fieldId}"
                     class="strategic-field strategic-textarea plan-306090-textarea"
                     data-field="plan_30_60_90.${horizon.key}"
-                    rows="5"
+                    rows="6"
                     placeholder="List key actions, owners, and outcomes…"
                 >${value}</textarea>
             </div>`;
-    }).join('')}</div>`;
+    }).join('');
 
-    return `${horizonsHtml}${buildClientCommitmentsHtml(planData)}`;
+    return `
+        <div class="plan-306090-board">
+            <div class="plan-306090-columns">
+                ${horizonColumns}
+                ${buildClientCommitmentsColumnHtml(planData)}
+            </div>
+        </div>`;
 }
 
 /**
- * Give/Get checklist under the 30/60/90 horizons — what the customer owes
- * us this month to keep the deal moving.
+ * Give/Get column — peer to the 30/60/90 horizons (not a footer band).
  *
  * @param {Record<string, unknown>} planData
  */
-function buildClientCommitmentsHtml(planData) {
+function buildClientCommitmentsColumnHtml(planData) {
     const items = Array.isArray(planData.client_commitments) ? planData.client_commitments : [];
     const inputId = 'client-commitments-input-plan_30_60_90';
 
-    const rowsHtml = items.length > 0
+    const chipsHtml = items.length > 0
         ? items.map((entry, index) => {
             const text = String(entry ?? '').trim();
             if (!text) return '';
             return `
-                <li class="blindspots-item client-commitments-item" data-client-commitments-index="${index}">
-                    <span class="blindspots-item-bullet" aria-hidden="true">▢</span>
-                    <span class="blindspots-item-text">${escapeHtml(text)}</span>
+                <li class="client-commitment-chip" data-client-commitments-index="${index}">
+                    <span class="client-commitment-chip__text">${escapeHtml(text)}</span>
                     <button
                         type="button"
-                        class="blindspots-item-remove"
+                        class="client-commitment-chip__remove"
                         data-client-commitments-remove="${index}"
                         aria-label="Remove commitment: ${escapeHtml(text)}"
                     >×</button>
                 </li>`;
         }).join('')
-        : `<li class="blindspots-empty">What does the customer owe us this month to keep the deal moving?</li>`;
+        : `<li class="client-commitment-chip client-commitment-chip--empty">What does the customer owe us this month to keep the deal moving?</li>`;
 
     return `
-        <div class="plan-306090-commitments" data-client-commitments-host>
-            <h5 class="plan-306090-commitments-title">${escapeHtml(TACTICAL_UX_LABELS.clientCommitments)}</h5>
-            <ul class="blindspots-list client-commitments-list" role="list">${rowsHtml}</ul>
-            <div class="blindspots-add-row">
+        <div class="plan-306090-column plan-306090-column--give-get" data-client-commitments-host>
+            <div class="plan-306090-column-head">
+                <span class="plan-306090-badge plan-306090-badge--give-get" aria-hidden="true">G↔</span>
+                <div class="plan-306090-column-heading">
+                    <h5 class="plan-306090-column-title">${escapeHtml(TACTICAL_UX_LABELS.giveGetColumn)}</h5>
+                    <p class="plan-306090-column-hint">What the customer owes us to keep momentum.</p>
+                </div>
+            </div>
+            <ul class="client-commitment-chips" role="list">${chipsHtml}</ul>
+            <div class="client-commitment-add-row">
                 <label class="sr-only" for="${inputId}">Add a client commitment</label>
                 <input
                     type="text"
                     id="${inputId}"
-                    class="strategic-field blindspots-add-input"
+                    class="strategic-field client-commitment-add-input"
                     data-client-commitments-input
-                    placeholder="What does the customer owe us this month to keep the deal moving?"
+                    placeholder="Add a give/get commitment…"
                     autocomplete="off"
                 />
-                <button type="button" class="blindspots-add-btn" data-client-commitments-add>Add</button>
+                <button type="button" class="client-commitment-add-btn" data-client-commitments-add>Add</button>
             </div>
         </div>`;
 }
@@ -1382,6 +1393,7 @@ function buildClientCommitmentsHtml(planData) {
  */
 function buildEntryPointPills(index, fieldKey, options, label, value) {
     const fieldPath = `entry_points.${index}.${fieldKey}`;
+    const shortLabel = ENTRY_POINT_ATTRIBUTE_SHORT_LABELS[fieldKey] || label;
     const pillOptions = options.filter((option) => option !== '');
     const pillsHtml = pillOptions.map((option) => {
         const active = value === option ? ' entry-point-pill--active' : '';
@@ -1397,8 +1409,8 @@ function buildEntryPointPills(index, fieldKey, options, label, value) {
     }).join('');
 
     return `
-        <div class="entry-point-field entry-point-field--pills">
-            <span class="entry-point-field-label">${escapeHtml(label)}</span>
+        <div class="entry-point-attribute-chip">
+            <span class="entry-point-attribute-chip__label">${escapeHtml(shortLabel)}</span>
             <div class="entry-point-pills-wrap" role="group" aria-label="${escapeHtml(label)}">${pillsHtml}</div>
         </div>`;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses formatting feedback on Strategic Entry Points and the 30/60/90 Give/Get block in the canvas and summary exports.

## Entry point attribute pills

- Export chips use a nested structure: short label on top, selected value below (`ap-export-attribute-pill`).
- Canvas relationship profile uses matching `entry-point-attribute-chip` containers so labels sit inside the bordered chip with option pills nested below.

## Give / Get integration

- **Canvas:** 30/60/90 is a four-column board; Give/Get is the fourth column (not a footer band). Commitments render as compact chips with an inline add row.
- **Dossier PDF:** Four-column editorial grid includes Give/Get as a peer column.
- **Exec summary deck:** Give/Get is the fourth column in the plan panel.
- **PPTX:** Execution roadmap table adds a fourth Give/Get column instead of a footer block.

## Files

- `js/account-plan-sections.js` — `giveGetColumn` label + short attribute labels
- `js/account-plan-ui.js` — column layout + attribute chips
- `js/account-plan-export-templates.js` — export/exec/dossier renderers + CSS
- `js/account-plan-presentation-pptx.js` — 4-column plan table
- `css/saos-strategic.css` — canvas styles
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9e31a0ad-59fc-4bb0-a425-2601630805f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9e31a0ad-59fc-4bb0-a425-2601630805f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

